### PR TITLE
feat(sdk): support scripts with versions

### DIFF
--- a/.changeset/red-rules-juggle.md
+++ b/.changeset/red-rules-juggle.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Support SporeScript with versions

--- a/packages/core/src/config/helpers.ts
+++ b/packages/core/src/config/helpers.ts
@@ -1,6 +1,8 @@
 import cloneDeep from 'lodash/cloneDeep';
 import { predefinedSporeConfigs } from './predefined';
-import { SporeConfig, SporeConfigScripts } from './types';
+import { ScriptId } from '../types';
+import { isScriptIdEquals } from '../helpers';
+import { SporeConfig, SporeScript, SporeScripts, SporeVersionedScript } from './types';
 
 const env: {
   config: SporeConfig;
@@ -25,16 +27,74 @@ export function getSporeConfig() {
 }
 
 /**
- * Get a specific Script from CNftConfig,
+ * Get a specific SporeScript from SporeConfig,
  * and throws an error if the script doesn't exist.
  */
-export function getSporeConfigScript(config: SporeConfig, scriptName: string) {
+export function getSporeScript(config: SporeConfig, scriptName: string): SporeVersionedScript;
+export function getSporeScript(config: SporeConfig, scriptName: string, scriptId?: ScriptId): SporeScript;
+export function getSporeScript(config: SporeConfig, scriptName: string, scriptId?: ScriptId) {
   const script = config.scripts[scriptName];
   if (!script) {
-    throw new Error(`${scriptName} script not defined in CNftConfig`);
+    throw new Error(`${scriptName} script is not defined in the SporeConfig`);
   }
 
-  return script;
+  if (!scriptId || isDirectSporeScript(script, scriptId)) {
+    return script;
+  }
+
+  const versioned = getSporeScriptVersion(script, scriptId);
+  if (!versioned) {
+    throw new Error(`${scriptName} script with a version is not defined in the SporeConfig`);
+  }
+  return versioned;
+}
+
+/**
+ * Find any version of a SporeScript by the specified ScriptId.
+ */
+export function getSporeScriptVersion(sporeScript: SporeVersionedScript, scriptId: ScriptId): SporeScript | undefined {
+  const versions = sporeScript.versions ?? [];
+  if (versions.length) {
+    for (const version of versions) {
+      if (isScriptIdEquals(version.script, scriptId)) {
+        return version;
+      }
+    }
+  }
+
+  return void 0;
+}
+
+/**
+ * Check if the target ScriptId is any version of the specified SporeScript.
+ * The difference between this function and the `isSporeScriptSupported` is,
+ * this function accepts SporeConfig and the name of SporeScript as parameters.
+ */
+export function isSporeScriptSupportedByName(config: SporeConfig, scriptName: string, scriptId: ScriptId) {
+  const script = getSporeScript(config, scriptName);
+  return isSporeScriptSupported(script, scriptId);
+}
+
+/**
+ * Check if the target ScriptId is any version of the specified SporeScript.
+ */
+export function isSporeScriptSupported(sporeScript: SporeVersionedScript, scriptId: ScriptId) {
+  if (isDirectSporeScript(sporeScript, scriptId)) return true;
+  return isVersionedSporeScript(sporeScript, scriptId);
+}
+
+/**
+ * Check if the target ScriptId is the latest version of the specified SporeScript.
+ */
+export function isDirectSporeScript(sporeScript: SporeScript, scriptId: ScriptId) {
+  return isScriptIdEquals(sporeScript.script, scriptId);
+}
+
+/**
+ * Check if the target ScriptId is an historical version of the specified SporeScript.
+ */
+export function isVersionedSporeScript(sporeScript: SporeVersionedScript, scriptId: ScriptId) {
+  return getSporeScriptVersion(sporeScript, scriptId) !== void 0;
 }
 
 /**
@@ -62,7 +122,7 @@ export function forkSporeConfig<T1 extends string, T2 extends string>(
   const scripts = {
     ...origin.scripts,
     ...change.scripts,
-  } as SporeConfigScripts<T1 | T2>;
+  } as SporeScripts<T1 | T2>;
 
   return {
     ...origin,

--- a/packages/core/src/config/predefined.ts
+++ b/packages/core/src/config/predefined.ts
@@ -4,37 +4,39 @@ import { SporeConfig } from './types';
 export type PredefinedSporeConfigScriptName = 'Spore' | 'Cluster';
 
 const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
+  lumos: predefined.AGGRON4,
+  ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
+  ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
   scripts: {
     Spore: {
       script: {
-        codeHash: '0x02d8136d628508ad53f67fccca6ae9744e98ee829783e8c30b8891be03d70ed2',
+        codeHash: '0xc1a7e2d2bd7e0fa90e2f1121782aa9f71204d1fee3a634bf3b12c61a69ee574f',
         hashType: 'data1',
       },
       cellDep: {
         outPoint: {
-          txHash: '0x209a39c4c93f603072cb01866a53d9e7064a1f63d4ba081e91b90b430062187e',
+          txHash: '0xdc6068c4e5469b8b4e1df23295f87cf2f568c41661cd481e81ae1dd4c8bc3797',
           index: '0x0',
         },
         depType: 'code',
       },
+      versions: [],
     },
     Cluster: {
       script: {
-        codeHash: '0x8d2f24b55961808ab81b312e3ea789677e7c11ad7c059bf6b0ca16382bb1818e',
+        codeHash: '0x598d793defef36e2eeba54a9b45130e4ca92822e1d193671f490950c3b856080',
         hashType: 'data1',
       },
       cellDep: {
         outPoint: {
-          txHash: '0x209a39c4c93f603072cb01866a53d9e7064a1f63d4ba081e91b90b430062187e',
-          index: '0x1',
+          txHash: '0x49551a20dfe39231e7db49431d26c9c08ceec96a29024eef3acc936deeb2ca76',
+          index: '0x0',
         },
         depType: 'code',
       },
+      versions: [],
     },
   },
-  lumos: predefined.AGGRON4,
-  ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
-  ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
   extensions: [],
 };
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -7,13 +7,19 @@ export interface SporeConfig<T extends string = string> {
   lumos: Config;
   ckbNodeUrl: string;
   ckbIndexerUrl: string;
-  scripts: SporeConfigScripts<T>;
   extensions: SporeExtension[];
+  scripts: SporeVersionedScripts<T>;
 }
 
-export type SporeConfigScripts<T extends string> = Record<T, SporeConfigScript>;
+export type SporeVersionedScripts<T extends string> = Record<T, SporeVersionedScript>;
 
-export interface SporeConfigScript {
+export interface SporeVersionedScript extends SporeScript {
+  versions?: SporeScript[];
+}
+
+export type SporeScripts<T extends string> = Record<T, SporeScript>;
+
+export interface SporeScript {
   script: ScriptId;
   cellDep: CellDep;
 }

--- a/packages/core/src/helpers/typeId.ts
+++ b/packages/core/src/helpers/typeId.ts
@@ -23,7 +23,7 @@ export function generateTypeId(firstInput: Cell, outputIndex: BIish): Hash {
 }
 
 /**
- * Generate TypeIds for a group of output cells.
+ * Generate TypeIds for a group of cells in Transaction.outputs.
  */
 export function generateTypeIdGroup(
   firstInput: Cell,
@@ -41,4 +41,30 @@ export function generateTypeIdGroup(
   }
 
   return group;
+}
+
+/**
+ * Generate TypeIds from a Transaction.outputs.
+ *
+ * This function is different from the `generateTypeIdGroup` function,
+ * because this function generates TypeIds based on each output's original index in the list,
+ * instead of generating them by each output's index in a group.
+ */
+export function generateTypeIdsByOutputs(
+  firstInput: Cell,
+  outputs: Cell[],
+  filter?: (cell: Cell) => boolean,
+): [number, Hash][] {
+  function filterOutput(cell: Cell): boolean {
+    return filter instanceof Function ? filter(cell) : true;
+  }
+
+  const result: [number, Hash][] = [];
+  for (let i = 0; i < outputs.length; i++) {
+    if (filterOutput(outputs[i])) {
+      result.push([i, generateTypeId(firstInput, i)]);
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
### Changes
- Support spore/cluster type script with versions
  - When creating spores/clusters, use the latest version
  - For transfering/destroying spores/clusters, use any supported version
- Change the logic of TypeId generation
  - From: group outputs by type script id, and generate a TypeId for each output by index in the group it belongs to
  - To: generate a TypeId for each output by index in the outputs list
- Update SporeType & ClusterType info (script id, cell dep)