### PR TITLE
feat(sdk): limiting tx size on creation apis

### DIFF
--- a/.changeset/fuzzy-worms-give.md
+++ b/.changeset/fuzzy-worms-give.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Add recipe doc about how to use SporeConfig

--- a/.changeset/spicy-badgers-chew.md
+++ b/.changeset/spicy-badgers-chew.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Add transaction max size limit to createSpore/createCluster APIs

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Provides real code examples to show developers how to construct transactions of 
   
 ### [Handle spore/cluster data](docs/recipes/handle-cell-data.md)
 
+### [Configure spore-sdk with SporeConfig](docs/recipes/configure-spore-config.md)
+
 ## License
 
 [MIT](./LICENSE) License

--- a/docs/recipes/configure-spore-config.md
+++ b/docs/recipes/configure-spore-config.md
@@ -1,0 +1,84 @@
+# Configure spore-sdk with SporeConfig
+
+## What is SporeConfig
+
+To create a spore on-chain, the spore-sdk needs to know the `ScriptId`/`CellDep` of the `SporeType` script.
+And when a transaction is ready to be sent on-chain, the spore-sdk needs to know the URL of the target RPC.
+Everything required by the spore-sdk is designed to be stored in a SporeConfig, which is a context object that stores/passes information.
+
+A SporeConfig object will have the following properties:
+
+> For the original/detailed type definition of SporeConfig, 
+> refer to: [@spore-sdk/core/src/config/types.ts](../../packages/core/src/config/types.ts).
+
+- `lumos`: Config for lumos. Refer to: [@ckb-lumos/config-manager](https://github.com/ckb-js/lumos/tree/develop/packages/config-manager).
+- `ckbNodeUrl`: CKB RPC node's URL, will be used when creating lumos/rpc instances. Refer to: [@ckb-lumos/rpc](https://github.com/ckb-js/lumos/tree/develop/packages/rpc).
+- `ckbIndexerUrl`: CKB Indexer node's URL, will be used when creating lumos/ckb-indexer instances. Refer to: [@ckb-lumos/ckb-indexer](https://github.com/ckb-js/lumos/tree/develop/packages/ckb-indexer).
+- `maxTransactionSize`: Specify the maximum size (in bytes) of single transactions, will be used in variants of APIs to prevent constructing oversize transactions.
+- `scripts`: Define necessary script infos, etc. ScriptId, CellDep. For instance the spore-sdk will use the script infos of Spore and Cluster.
+- `extensions`: Define what SporeExtension(s) to be used in the spore-sdk. Note: this part is WIP (working in progress).
+
+## Common usages
+
+### Use the predefined configs
+
+When using the spore-sdk, developers might want to specify a SporeConfig in order to make actions on a target environment. The spore-sdk provides a `predefinedSporeConfigs` with mainnet/testnet predefined configurations for developers to switch to these environments faster, which contains:
+
+- `Aggron4`: A SporeConfig object containing Spore Protocol infos on CKB Testnet (Aggron4).
+- `Lina (Not presented yet)`: A SporeConfig object containing Spore Protocol infos on CKB Mainnet (Lina). Note the Spore Protocol is not on mainnet yet, therefore the option is only a placeholder, we'll update it as soon as the Spore Protocol goes on mainnet.
+
+The spore-sdk uses `predefinedSporeConfigs.Aggron4` as the default config.  
+But for example, if you want to create a spore on mainnet instead of testnet, specify it like this:
+
+```typescript
+import { predefinedSporeConfigs, createSpore } from '@spore-sdk/core';
+
+const result = await createSpore({
+  data: {
+    contentType: 'image/jpeg',
+    content: JPEG_AS_BYTES,
+  },
+  fromInfos: [WALLET_ADDRESS],
+  toLock: WALLET_LOCK,
+  config: predefinedSporeConfigs.Lina, // using the mainnet config
+});
+```
+
+### Set config globally
+
+To use a SporeConfig without passing it everywhere:
+
+```typescript
+import { predefinedSporeConfigs, setSporeConfig, createSpore } from '@spore-sdk/core';
+
+// Setting testnet config as the global default
+setSporeConfig(predefinedSporeConfigs.Aggron4);
+
+// No need to pass the config object in the props
+const result = await createSpore({
+  data: {
+    contentType: 'image/jpeg',
+    content: JPEG_AS_BYTES,
+  },
+  fromInfos: [WALLET_ADDRESS],
+  toLock: WALLET_LOCK,
+});
+```
+
+### Fork a predefined config
+
+When some properties in a predefined SporeConfig is not fit for a developer, the developer can fork the predefined config and create a new one. For example, if a developer can tune down the `maxTransactionSize` number in the testnet's config like this: 
+
+```typescript
+import { predefinedSporeConfigs, forkSporeConfig } from '@spore-sdk/core';
+
+// The forked config is a deep clone of the original config 
+const newAggron4 = forkSporeConfig(predefinedSporeConfigs.Aggron4, {
+  maxTransactionSize: 100,
+});
+
+// The two configs has different maxTransactionSize values
+console.log(newAggron4.maxTransactionSize === predefinedSporeConfigs.Aggron4); // false
+```
+
+

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -36,6 +36,8 @@ yarn add @spore-sdk/core
 
 ### [Handle spore/cluster data](../../docs/recipes/handle-cell-data.md)
 
+### [Configure spore-sdk with SporeConfig](../../docs/recipes/configure-spore-config.md)
+
 ## Examples
 
 ### [@spore-examples/secp256k1](../../examples/secp256k1)

--- a/packages/core/src/api/composed/cluster/createCluster.ts
+++ b/packages/core/src/api/composed/cluster/createCluster.ts
@@ -3,6 +3,7 @@ import { FromInfo } from '@ckb-lumos/common-scripts';
 import { Address, Script } from '@ckb-lumos/base';
 import { BIish } from '@ckb-lumos/bi';
 import { getSporeConfig, SporeConfig } from '../../../config';
+import { assetTransactionSkeletonSize } from '../../../helpers';
 import { injectCapacityAndPayFee, setCellAbsoluteCapacityMargin } from '../../../helpers';
 import { ClusterDataProps, injectClusterIds, injectNewClusterOutput } from '../../joints/cluster';
 
@@ -13,6 +14,7 @@ export async function createCluster(props: {
   config?: SporeConfig;
   changeAddress?: Address;
   capacityMargin?: BIish;
+  maxTransactionSize?: number | false;
   updateOutput?(cell: Cell): Cell;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -22,6 +24,7 @@ export async function createCluster(props: {
   const config = props.config ?? getSporeConfig();
   const indexer = new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl);
   const capacityMargin = BI.from(props.capacityMargin ?? 1_0000_0000);
+  const maxTransactionSize = props.maxTransactionSize ?? config.maxTransactionSize ?? false;
 
   // Get TransactionSkeleton
   let txSkeleton = helpers.TransactionSkeleton({
@@ -60,6 +63,11 @@ export async function createCluster(props: {
     txSkeleton,
     config,
   });
+
+  // Make sure the tx size is in range (if needed)
+  if (typeof maxTransactionSize === 'number') {
+    assetTransactionSkeletonSize(txSkeleton, void 0, maxTransactionSize);
+  }
 
   return {
     txSkeleton,

--- a/packages/core/src/config/predefined.ts
+++ b/packages/core/src/config/predefined.ts
@@ -7,6 +7,7 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
   lumos: predefined.AGGRON4,
   ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
   ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
+  maxTransactionSize: 500 * 1024, // 500 KB
   scripts: {
     Spore: {
       script: {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -7,8 +7,9 @@ export interface SporeConfig<T extends string = string> {
   lumos: Config;
   ckbNodeUrl: string;
   ckbIndexerUrl: string;
-  extensions: SporeExtension[];
+  maxTransactionSize?: number;
   scripts: SporeVersionedScripts<T>;
+  extensions: SporeExtension[];
 }
 
 export type SporeVersionedScripts<T extends string> = Record<T, SporeVersionedScript>;

--- a/packages/core/src/helpers/transaction.ts
+++ b/packages/core/src/helpers/transaction.ts
@@ -8,7 +8,7 @@ import { helpers } from '@ckb-lumos/lumos';
  * [Calculate transaction fee](https://github.com/nervosnetwork/ckb/wiki/Transaction-%C2%BB-Transaction-Fee#calculate-transaction-fee)
  */
 export function getTransactionSize(tx: Transaction): number {
-  const serializedTx = blockchain.Transaction.pack(tx);
+  const serializedTx = blockchain.RawTransaction.pack(tx);
   return 4 + serializedTx.buffer.byteLength;
 }
 
@@ -18,4 +18,56 @@ export function getTransactionSize(tx: Transaction): number {
 export function getTransactionSkeletonSize(txSkeleton: helpers.TransactionSkeletonType): number {
   const tx = helpers.createTransactionFromSkeleton(txSkeleton);
   return getTransactionSize(tx);
+}
+
+/**
+ * Check if the Transaction's size (in bytes) is as expected.
+ * Expected: min < size <= max.
+ */
+export function isTransactionSizeInRange(tx: Transaction, min?: number, max?: number): boolean {
+  const size = getTransactionSize(tx);
+  return size <= (min ?? 0) || size > (max ?? Infinity);
+}
+
+/**
+ * Check if the TransactionSkeleton's size (in bytes) is as expected.
+ * Expected: min < size <= max.
+ */
+export function isTransactionSkeletonSizeInRange(
+  txSkeleton: helpers.TransactionSkeletonType,
+  min?: number,
+  max?: number,
+): boolean {
+  const tx = helpers.createTransactionFromSkeleton(txSkeleton);
+  return isTransactionSizeInRange(tx, min, max);
+}
+
+/**
+ * Throw an error if the Transaction's size (in bytes) is not as expected.
+ * Expected: min < size <= max.
+ */
+export function assetTransactionSize(tx: Transaction, min?: number, max?: number): void {
+  min = min ?? 0;
+  max = max ?? Infinity;
+
+  const size = getTransactionSize(tx);
+  if (size <= min) {
+    throw new Error(`Expected the transaction size to be > ${min}, actual size: ${size}`);
+  }
+  if (size > max) {
+    throw new Error(`Expected the transaction size to be <= ${max}, actual size: ${size}`);
+  }
+}
+
+/**
+ * Throw an error if the TransactionSkeleton's size (in bytes) is not as expected.
+ * Expected: min < size <= max.
+ */
+export function assetTransactionSkeletonSize(
+  txSkeleton: helpers.TransactionSkeletonType,
+  min?: number,
+  max?: number,
+): void {
+  const tx = helpers.createTransactionFromSkeleton(txSkeleton);
+  assetTransactionSize(tx, min, max);
 }


### PR DESCRIPTION
### Changes
1. Limiting the tx size on creation apis (createSpore/createCluster)
    - Add a `maxTransactionSize` option to SporeConfig type, for setting the value globally
    - Add a `maxTransactionSize` option in creation apis, default to SporeConfig.maxTransactionSize (to disable it, pass `false`)
2. Add recipe doc of "Configure spore-sdk with SporeConfig"
    - The doc teaches developers how to use/fork configs