### PR TITLE
fix(sdk): transaction size calculation

### DIFF
--- a/.changeset/tasty-boats-obey.md
+++ b/.changeset/tasty-boats-obey.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Fix wrong molecule used in transaction size calculation

--- a/packages/core/src/helpers/transaction.ts
+++ b/packages/core/src/helpers/transaction.ts
@@ -8,7 +8,7 @@ import { helpers } from '@ckb-lumos/lumos';
  * [Calculate transaction fee](https://github.com/nervosnetwork/ckb/wiki/Transaction-%C2%BB-Transaction-Fee#calculate-transaction-fee)
  */
 export function getTransactionSize(tx: Transaction): number {
-  const serializedTx = blockchain.RawTransaction.pack(tx);
+  const serializedTx = blockchain.Transaction.pack(tx);
   return 4 + serializedTx.buffer.byteLength;
 }
 


### PR DESCRIPTION
### Changes
-  Fixed an incorrect fee estimation issue, where wrong molecule was used to calculate transaction size

### Contributors
- Thanks to @ahonn for spotting the issue