### PR TITLE
docs(sdk|docs): refactor readme and recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you intend to use the Spore SDK in a browser environment, it's important to n
 
 - [Composed APIs](./docs/core/composed-apis.md) - APIs for efficient spores/clusters. interactions with minimal time overhead
 
-- [Joint APIs](./docs/core/joint-apis.md) - APIs for building advanced transactions as a fun block-building process.
+- [Joint APIs](./docs/core/joint-apis.md) (WIP) - APIs for building advanced transactions as a fun block-building process.
  
  
 ## Community

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  A <a href="https://github.com/ckb-js/lumos">Lumos</a> based TypeScript SDK to interact with Spore Protocol.
+  A TypeScript SDK to interact with Spore Protocol.
 </p>
 
 <p align="center">
@@ -29,23 +29,40 @@
   </a>
 </p>
 
+## Intro
+
+Spore SDK is a Web development kit for integration with [Spore Protocol](https://github.com/sporeprotocol/spore-contract), an asset protocol for valuing on-chain contents, build on top of [CKB](https://github.com/nervosnetwork/ckb).
+It leverages the power of [Lumos](https://github.com/ckb-js/lumos) to provide seamless dapp development with Spore.
+
+
 ## Features
 
 - ⚡ Composed APIs for efficient spores/clusters interactions with minimal time overhead
 - 🧩 Joint APIs for building advanced transactions as a fun block-building process
 - 🛠️ Utilities for encoding/decoding data of spores/clusters
-- 💖 Designed and implemented based on [Lumos](https://github.com/ckb-js/lumos)
 - 🎹 Fully written in TypeScript
+
+
+## Documentation
+
+For full documentation and instructions, visit [docs.spore.pro](https://docs.spore.pro).
+
 
 ## Getting started
 
-Start using spore-sdk with the `spore-first-example`:
+### Create your first spore in Node.js
 
-https://github.com/sporeprotocol/spore-first-example/blob/0fd0a79fdbfab06c0d11c08011f457986fa85d93/src/index.ts#L4-L20
+Follow the step-by-step tutorial to create your first spore: [Creating your first Spore](https://docs.spore.pro/tutorials/create-first-spore).
 
-Follow the recipes to learn and explore the usage of spore-sdk: 
+Or you can run and play with the [spore-first-example](https://github.com/sporeprotocol/spore-first-example) on [StackBlitz](https://stackblitz.com/github/sporeprotocol/spore-first-example?file=src%2Findex.ts&view=editor).
 
-- [Construct transactions with spore-sdk](docs/recipes/construct-transaction.md)
+### Follow the recipes
+
+Visit the Spore Docs for more categorized and general [How-to recipes](https://docs.spore.pro/category/how-to).
+
+Or study the following recipes to explore the usage of the SDK:
+
+- [Construct transactions with Spore SDK](docs/recipes/construct-transaction.md)
 
 - [Create immortal spores on-chain](docs/recipes/create-immortal-spore.md)
 
@@ -53,39 +70,49 @@ Follow the recipes to learn and explore the usage of spore-sdk:
 
 - [Handle spore/cluster data](docs/recipes/handle-cell-data.md)
 
-- [Configure spore-sdk with SporeConfig](docs/recipes/configure-spore-config.md)
+- [Configure Spore SDK](docs/recipes/configure-spore-config.md)
 
-## Packages
+### Building browser env dapps
 
-### [@spore-sdk/core](./packages/core)
+The Spore SDK is built on top of [Lumos](https://github.com/ckb-js/lumos), an open-source dapp framework for Nervos CKB. Lumos incorporates certain Node-polyfills into its implementation, such as `crypto-browserify` and `buffer`, to provide specific functionalities.
 
-The core library of spore-sdk, providing everything developers need to construct basic and advanced transactions on spores and clusters, and handling [molecule](https://github.com/nervosnetwork/molecule) of spores/clusters from human-readable content to binary, or vice versa.
+If you intend to use the Spore SDK in a browser environment, it's important to note that you may need to manually add Node-polyfills to your application. This ensures that the Spore SDK functions properly in the browser. For detailed instructions on how to add these polyfills, refer to the Lumos documentation: [CRA, Vite, Webpack or Other](https://lumos-website.vercel.app/recipes/cra-vite-webpack-or-other).
 
-## Examples
+## Development
 
-### [Secp256k1Blake160 Sign-all](./examples/secp256k1)
+### Packages & toolchains
 
-Start with the most commonly used lock in Nervos CKB to:
+- [@spore-sdk/core](./packages/core) - Provides essential tools for constructing basic and advanced transactions on spores and clusters. Additionally, it offers convenient utilities for handling [serialization](https://github.com/nervosnetwork/molecule) of spores/clusters.
 
-- Create/transfer clusters with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
-- Create/transfer/destroy spores with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
+### Code references
 
-### [Anyone-can-pay](./examples/acp)
+- [Examples](./docs/resources/examples.md) - Code block examples for implementing basic and specific features.
 
-[Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) (ACP) lock can be unlocked by anyone without signature verification and accepts any amount of CKB or UDT payment from the unlocker. 
-Use its flexibility to:
+- [Demos](./docs/resources/demos.md) - Demo applications with full functionality, including seamless integration with wallets.
 
-- Create public clusters with the [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock
-- Create spores in public clusters with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
 
-### [Omnilock](./examples/omnilock)
+### APIs
 
-[Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) lock is an interoperable lock script supporting various blockchains (Bitcoin, Ethereum, EOS, etc.) verification methods and extensible for future additions. 
-It also offers a regulation compliance module for administrator-controlled token revocation, enabling registered assets like Apple stock on CKB when combined with the RCE (Regulation Compliance Extension). 
-Omnilock can be integrated with spore-sdk to:
+- [Composed APIs](./docs/core/composed-apis.md) - APIs for efficient spores/clusters. interactions with minimal time overhead
 
-- Create public clusters with the [Omnilock ACP](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode) lock
-- Create spores in public clusters with the [Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) lock
+- [Joint APIs](./docs/core/joint-apis.md) - APIs for building advanced transactions as a fun block-building process.
+ 
+ 
+## Community
+
+Reach out to us if you have questions about Spore Protocol:
+- Join the community on: [ HaCKBee - Discord](https://discord.gg/9eufnpZZ8P)
+- Contact via email at [contact@spore.pro](mailto:contact@spore.pro)
+
+## Contributing
+
+To contribute and assist in enhancing the Spore SDK, we welcome your pull requests:
+
+- `Active Branch` - By default, you can submit pull requests to the `beta` branch.
+
+- `Commit Styling` - Ensure that your commit styling does not conflict with the [existing commits](https://github.com/sporeprotocol/spore-sdk/commits).
+
+- `Clear Information` - Please provide a clear and descriptive title and description for your pull requests.
 
 ## License
 

--- a/docs/core/composed-apis.md
+++ b/docs/core/composed-apis.md
@@ -1,0 +1,246 @@
+# Composed API
+
+### createSpore
+
+```typescript
+declare function createSpore(props: {
+  data: SporeDataProps;
+  fromInfos: FromInfo[];
+  toLock: Script;
+  config?: SporeConfig;
+  changeAddress?: Address;
+  capacityMargin?: BIish;
+  updateOutput?(cell: Cell): Cell;
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+  cluster?: {
+    inputIndex: number;
+    outputIndex: number;
+  };
+}>;
+
+interface SporeDataProps {
+  contentType: string;
+  contentTypeParameters?: EncodableContentType['parameters'];
+  content: BytesLike;
+  clusterId?: HexString;
+}
+```
+
+**Props**
+
+- `data`: Specifies the data of the new spore.
+- `fromInfos`: Specifies where to collect capacity for transaction construction.
+- `toLock`: Specifies the owner of the new spore.
+- `config`: Specifies the config of the SDK.
+- `changeAddress`: Specifies the change cell's ownership.
+- `capacityMargin`: Specifies the capacity margin of the new spore, default to "BI.from(1_0000_0000)".
+- `updateOutput`: Specifies a callback function to update the spore output as needed.
+
+**SporeDataProps**
+
+- `contentType`: MIME of the spore's content, for example: "image/jpeg;a=1;b=2".
+- `contentTypeParameters`: An object of contentType parameters, usually you can pass extension parameters in here, and the object will be merged into contentType during the process of transaction construction. For example if the contentType is "image/jpeg;a=1", and you've passed "{ b: 2 }" in the contentTypeParameters, later the contentType will be modified to "image/jpeg;ext1=true;ext2=true".
+- `content`: The spore's content as bytes, for example if creating a spore where its contentType is "image/jpeg", then its content should be an .jpeg image as bytes.
+- `clusterId`: The spore's cluster ID, should be a 32-byte hash if exists.
+
+**Example**
+
+```typescript
+import { createSpore, predefinedSporeConfigs } from '@spore-sdk/core';
+
+const result = await createSpore({
+  data: {
+    content: JPEG_AS_BYTES,
+    contentType: 'image/jpeg',
+    contentTypeParameters: {
+      ext1: true,
+      ext2: 1,
+    },
+  },
+  fromInfos: [OWNER_ADDRESS],
+  toLock: OWNER_LOCK_SCRIPT,
+  config: predefinedSporeConfigs.Aggron4,
+});
+```
+
+### transferSpore
+
+```typescript
+declare function transferSpore(props: {
+  outPoint: OutPoint;
+  fromInfos: FromInfo[];
+  toLock: Script;
+  config?: SporeConfig;
+  changeAddress?: Address;
+  capacityMargin?: BIish;
+  useCapacityMarginAsFee?: boolean;
+  updateOutput?(cell: Cell): Cell;
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+}>;
+```
+
+**Props**
+
+- `outPoint`: Specifies a target spore to transfer.
+- `fromInfos`: Specifies where to collect capacity for transaction construction.
+- `toLock`: Specifies the new owner of the spore.
+- `config`: Specifies the config of the SDK.
+- `changeAddress`: Specifies the change cell's ownership.
+- `capacityMargin`: Specifies the capacity margin of the live spore. When "useCapacityMarginAsFee" is true, this prop should not be included in the props.
+- `useCapacityMarginAsFee`: Specifies whether to pay fee with the target spore's capacity margin, if not, the transaction is paid with capacity collected from the fromInfos, default to "true".
+- `updateOutput`: Specifies a callback function to update the target spore output as needed.
+
+**Example**
+
+```typescript
+import { transferSpore, predefinedSporeConfigs } from '@spore-sdk/core';
+
+const result = await transferSpore({
+  outPoint: {
+    txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
+    index: '0x0',
+  },
+  fromInfos: [OWNER_ADDRESS],
+  toLock: RECEIVER_LOCK_SCRIPT,
+  config: predefinedSporeConfigs.Aggron4,
+});
+```
+
+### destroySpore
+
+```typescript
+declare function destroySpore(props: {
+  outPoint: OutPoint;
+  fromInfos: FromInfo[];
+  config?: SporeConfig;
+  changeAddress?: Address;
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+}>;
+```
+
+**Props**
+
+- `outPoint`: Specifies a target spore to destroy.
+- `fromInfos`: Specifies where to collect capacity for transaction construction.
+- `config`: Specifies the config of the SDK.
+- `changeAddress`: Specifies the change cell's ownership.
+
+**Example**
+
+```typescript
+import { destroySpore, predefinedSporeConfigs } from '@spore-sdk/core';
+
+const result = await destroySpore({
+  outPoint: {
+    txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
+    index: '0x0',
+  },
+  fromInfos: [OWNER_ADDRESS],
+  config: predefinedSporeConfigs.Aggron4,
+});
+```
+
+### createCluster
+
+```typescript
+declare function createCluster(props: {
+  data: ClusterDataProps;
+  fromInfos: FromInfo[];
+  toLock: Script;
+  config?: SporeConfig;
+  changeAddress?: Address;
+  capacityMargin?: BIish;
+  updateOutput?(cell: Cell): Cell;
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+}>;
+
+interface ClusterDataProps {
+  name: string;
+  description: string;
+}
+```
+
+**Props**
+
+- `data`: Specifies the data of the new cluster.
+- `fromInfos`: Specifies where to collect capacity for transaction construction.
+- `toLock`: Specifies the owner of the new cluster.
+- `config`: Specifies the config of the SDK.
+- `changeAddress`: Specifies the change cell's ownership.
+- `capacityMargin`: Specifies the capacity margin of the new cluster, default to "BI.from(1_0000_0000)".
+- `updateOutput`: Specifies a callback function to update the cluster output as needed.
+
+**ClusterDataProps**
+
+- `name`: The name of the new cluster.
+- `description`: The description text of the new cluster.
+
+**Example**
+
+```typescript
+import { createCluster, predefinedSporeConfigs } from '@spore-sdk/core';
+
+const result = await createCluster({
+  data: {
+    name: 'Cluster name',
+    description: 'Description of the cluster',
+  },
+  fromInfos: [OWNER_ADDRESS],
+  toLock: OWNER_LOCK_SCRIPT,
+  config: predefinedSporeConfigs.Aggron4,
+});
+```
+
+### transferCluster
+
+```typescript
+declare function transferCluster(props: {
+  outPoint: OutPoint;
+  fromInfos: FromInfo[];
+  toLock: Script;
+  config?: SporeConfig;
+  changeAddress?: Address;
+  capacityMargin?: BIish;
+  useCapacityMarginAsFee?: boolean;
+  updateOutput?(cell: Cell): Cell;
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+}>;
+```
+
+**Props**
+
+- `outPoint`: Specifies a target cluster to destroy.
+- `fromInfos`: Specifies where to collect capacity for transaction construction.
+- `config`: Specifies the config of the SDK.
+- `changeAddress`: Specifies the change cell's ownership.
+- `capacityMargin`: Specifies the capacity margin of the live cluster. When "useCapacityMarginAsFee" is true, this prop should not be included in the props.
+- `useCapacityMarginAsFee`: Specifies whether to pay fee with the target cluster cell's capacity margin, if not, the transaction will be paid with capacity collected from the fromInfos, default to "true".
+- `updateOutput`: Specifies a callback function to update the target spore output as needed.
+
+**Example**
+
+```typescript
+import { transferCluster, predefinedSporeConfigs } from '@spore-sdk/core';
+
+const result = await transferCluster({
+  outPoint: {
+    txHash: '0xb1f94d7d8e8441bfdf1fc76639d12f4c3c391b8c8a18ed558e299674095290c3',
+    index: '0x0',
+  },
+  fromInfos: [OWNER_ADDRESS],
+  toLock: RECEIVER_LOCK_SCRIPT,
+  config: predefinedSporeConfigs.Aggron4,
+});
+```

--- a/docs/core/joint-apis.md
+++ b/docs/core/joint-apis.md
@@ -1,0 +1,1 @@
+# Joint APIs

--- a/docs/core/joint-apis.md
+++ b/docs/core/joint-apis.md
@@ -1,1 +1,3 @@
 # Joint APIs
+
+> This documentation is a work in progress.

--- a/docs/recipes/capacity-margin.md
+++ b/docs/recipes/capacity-margin.md
@@ -4,7 +4,7 @@
 
 In a typical CKB transaction, the sender usually pays the transaction fee by collecting additional cells from the sender's address and deducting the fee from the collected cells. 
 
-However, the spore-sdk provides a built-in support of adjusting the capacity margin of cluster/spore cells, which allows the sender to pay fees by a cluster/spore cell's capacity margin, instead of collecting additional cells while transaction's construction.
+However, the Spore SDK provides a built-in support of adjusting the capacity margin of cluster/spore cells, which allows the sender to pay fees by a cluster/spore cell's capacity margin, instead of collecting additional cells while transaction's construction.
 
 The usages of capacity margin for spores/clusters:
 
@@ -58,7 +58,7 @@ the sender has to collect additional cells to pay for the fee.
 
 ### When transferring spores/clusters
 
-By default, the spore-sdk will use capacity margin to pay fee when transferring a spore/cluster. As an example, the sender doesn't have to configure anything when transferring a spore:
+By default, the Spore SDK will use capacity margin to pay fee when transferring a spore/cluster. As an example, the sender doesn't have to configure anything when transferring a spore:
 
 ```typescript
 import { transferSpore } from '@spore-sdk/core';

--- a/docs/recipes/configure-spore-config.md
+++ b/docs/recipes/configure-spore-config.md
@@ -1,10 +1,10 @@
-# Configure spore-sdk with SporeConfig
+# Configure Spore SDK with SporeConfig
 
 ## What is SporeConfig
 
-To create a spore on-chain, the spore-sdk needs to know the `ScriptId`/`CellDep` of the `SporeType` script.
-And when a transaction is ready to be sent on-chain, the spore-sdk needs to know the URL of the target RPC.
-Everything required by the spore-sdk is designed to be stored in a SporeConfig, which is a context object that stores/passes information.
+To create a spore on-chain, the Spore SDK needs to know the `ScriptId`/`CellDep` of the `SporeType` script.
+And when a transaction is ready to be sent on-chain, the Spore SDK needs to know the URL of the target RPC.
+Everything required by the Spore SDK is designed to be stored in a SporeConfig, which is a context object that stores/passes information.
 
 A SporeConfig object will have the following properties:
 
@@ -15,19 +15,19 @@ A SporeConfig object will have the following properties:
 - `ckbNodeUrl`: CKB RPC node's URL, will be used when creating lumos/rpc instances. Refer to: [@ckb-lumos/rpc](https://github.com/ckb-js/lumos/tree/develop/packages/rpc).
 - `ckbIndexerUrl`: CKB Indexer node's URL, will be used when creating lumos/ckb-indexer instances. Refer to: [@ckb-lumos/ckb-indexer](https://github.com/ckb-js/lumos/tree/develop/packages/ckb-indexer).
 - `maxTransactionSize`: Specify the maximum size (in bytes) of single transactions, will be used in variants of APIs to prevent constructing oversize transactions.
-- `scripts`: Define necessary script infos, etc. ScriptId, CellDep. For instance the spore-sdk will use the script infos of Spore and Cluster.
-- `extensions`: Define what SporeExtension(s) to be used in the spore-sdk. Note: this part is WIP (working in progress).
+- `scripts`: Define necessary script infos, etc. ScriptId, CellDep. For instance, the Spore SDK will use the script infos of Spore and Cluster.
+- `extensions`: Define what SporeExtension(s) to be used in the Spore SDK. Note: this part is WIP (working in progress).
 
 ## Common usages
 
 ### Use the predefined configs
 
-When using the spore-sdk, developers might want to specify a SporeConfig in order to make actions on a target environment. The spore-sdk provides a `predefinedSporeConfigs` with mainnet/testnet predefined configurations for developers to switch to these environments faster, which contains:
+When using the Spore SDK, developers might want to specify a SporeConfig to make actions on a target environment. The Spore SDK provides a `predefinedSporeConfigs` with mainnet/testnet predefined configurations for developers to switch to these environments faster, which contains:
 
 - `Aggron4`: A SporeConfig object containing Spore Protocol infos on CKB Testnet (Aggron4).
 - `Lina (Not presented yet)`: A SporeConfig object containing Spore Protocol infos on CKB Mainnet (Lina). Note the Spore Protocol is not on mainnet yet, therefore the option is only a placeholder, we'll update it as soon as the Spore Protocol goes on mainnet.
 
-The spore-sdk uses `predefinedSporeConfigs.Aggron4` as the default config.  
+The Spore SDK uses `predefinedSporeConfigs.Aggron4` as the default config.  
 But for example, if you want to create a spore on mainnet instead of testnet, specify it like this:
 
 ```typescript

--- a/docs/recipes/construct-transaction.md
+++ b/docs/recipes/construct-transaction.md
@@ -1,18 +1,18 @@
 
-# Construct transactions with spore-sdk
+# Construct transactions with Spore SDK
 
-## The spore-sdk
+## The Spore SDK
 
-As an SDK designed to interact with the Spore Protocol, the primary mission of the spore-sdk is to provide developers with everything necessary to engage with the spores/clusters on-chain. 
+As an SDK designed to interact with the Spore Protocol, the primary mission of the Spore SDK is to provide developers with everything necessary to engage with the spores/clusters on-chain. 
 
-Key functionalities of the spore-sdk:
+Key functionalities of the Spore SDK:
 
 1. Construct spores/clusters transactions
 2. Encode and decode the cell data of spores/clusters
 3. Simplify application and service development with helpful utilities
 
-So, let's start by peeling off a corner of the spore-sdk. 
-The following instructions will focus on the first functionality, demonstrating how to create a spore on-chain using spore-sdk by constructing a transaction.
+So, let's start by peeling off a corner of the Spore SDK. 
+The following instructions will focus on the first functionality, demonstrating how to create a spore on-chain using Spore SDK by constructing a transaction.
 
 ## Create a transaction
 

--- a/docs/resources/demos.md
+++ b/docs/resources/demos.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 3
+sidebar_label: Demos
+---
+
+# Spore Demos
+
+Spore Demos are web application demos that can be run in a browser environment.
+
+The demos are more complete projects than the [Spore Examples](./examples.md), developers can study from the demos to understand how fully functional web applications are developed. 
+For example, how to connect wallets like [MetaMask](https://metamask.io) or [JoyID](https://joy.id).
+
+### A simple `Next.js` demo
+
+A Spore Protocol Demo based on Next.js + React + Spore SDK, which implements basic functionalities, such as the creation and transfer of clusters, as well as minting, transferring, and destroying of spores. 
+
+The demo also shows how to connect with [MetaMask](https://metamask.io) and [JoyID](https://joy.id) wallets.
+
+- [Online A-simple-demo app](https://a-simple-demo.spore.pro)
+- [GitHub repository](https://github.com/sporeprotocol/spore-demo)

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -1,0 +1,38 @@
+# Spore Examples
+
+Here we provide several examples which are minimum viable snippets designed for a Node environment, each showcasing a specific feature implemented using the [Spore SDK](../..).
+
+These examples serve as practical guides for developers, demonstrating how to implement specific features in a straightforward manner, for instance, how to create a spore by a transaction with Spore SDK. And for those who are looking for documentation on how to develop a fully functional application, refer to: [Spore Demos](./demos).
+
+## Scenario examples
+
+### [Creating your first spore](https://docs.spore.pro/tutorials/create-first-spore)
+
+[`spore-first-example`](https://github.com/sporeprotocol/spore-first-example) is a hello world example for Spore SDK, showing you how to upload an image file and create a spore on [Nervos CKB](https://www.nervos.org/) in a split second. This is a well-suited code example for beginners to learn the very basics of Spore Protocol.
+
+- Follow the tutorial at [Creating your first spore](https://docs.spore.pro/tutorials/create-first-spore)
+- Run the example on [StackBlitz](https://stackblitz.com/github/sporeprotocol/spore-first-example?file=src%2Findex.ts)
+- [GitHub repository](https://github.com/sporeprotocol/spore-first-example)
+
+## Lock script examples
+
+### [CKB Default Lock](../../examples/secp256k1)
+
+[CKB Default Lock](https://www.notion.so/cryptape/examples/secp256k1) is the most commonly used lock script on [Nervos CKB](https://www.nervos.org/), also a great starting point for beginners due to its simplicity. You can create private spores and clusters with the [CKB Default Lock](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) for safeguarding ownership of your private assets.
+
+- Create/transfer clusters with the [CKB Default Lock](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c)
+- Create/transfer/destroy spores with the [CKB Default Lock](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c)
+
+### [Anyone-can-pay](../../examples/acp)
+
+[Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) (ACP) lock can be unlocked by anyone without signature verification and accepts any amount of CKB/UDT payment from the unlocker. You can create public clusters with the [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock and benefit from charging other users for creating spores within the public cluster.
+
+- Create public clusters with the [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock
+- Create spores in public clusters with the [CKB Default Lock](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c)
+
+### [Omnilock](../../examples/omnilock)
+
+[Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) is a universal and interoperable lock script supporting various blockchains (Bitcoin, Ethereum, EOS, etc.) verification methods and extensible for future additions. [Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) also supports a [compatible anyone-can-pay mode](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode), which allows you to create public clusters using it. You can create private/public spores and clusters with the [Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md).
+
+- Create public clusters with the [Omnilock ACP](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode) lock
+- Create spores in public clusters with the [Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) lock

--- a/examples/acp/README.md
+++ b/examples/acp/README.md
@@ -1,21 +1,15 @@
 # Spore ACP Examples
 
-## Introduction
+## What is `Anyone-can-pay` lock
 
-### What is `Anyone-can-pay` lock
+[Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) (ACP) lock is designed to be unlocked by anyone without signature verification and accepts any amount of CKB/UDT payment from the unlocker. You can create public clusters with the [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock and benefit from charging other users for creating spores within the public cluster.
 
-[Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) is a lock script designed to accept any amount of CKB or UDT payment from any sender. An ACP lock cell can be unlocked by anyone without signature verification if the unlocker can meet the lock's requirements.
+Refer to the RFC for more detailed rules: [CKB RFC 0026: Anyone-can-pay Lock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md#script-structure).
 
-For instance, if A wants to transfer some CKB to B, normally A has to create a new cell to B, containing at least 61 CKB (if B is Secp256k1Blake160 Sign-all lock) of capacity.
-But if B has an ACP lock cell on-chain, A can just unlock the ACP lock cell and add any amount of CKB into the cell, without signature verification from B. 
+## Featured examples
 
-### Featured examples
-
-The Spore ACP Examples is a collection of code examples to show developers how to achieve different purposes with Anyone-can-pay lock and spore-sdk.
-
-In [`/apis`](./apis):
-- Create public clusters with the [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock
-- Create spores in public clusters with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
+- [apis/createAcpCluster.ts](./apis/createAcpCluster.ts): Create a public cluster with the [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock
+- [apis/createSporeInAcpCluster.ts](./apis/createSporeInAcpCluster.ts): Create a [CKB Default Lock](https://www.notion.so/cryptape/examples/secp256k1) private spore within an [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock cluster
 
 ## Run examples
 
@@ -25,7 +19,7 @@ In [`/apis`](./apis):
 
 ### Setup environment
 
-To set up the local environment, run the following command at the spore-sdk's root directory:
+To set up the local environment, run the following command at the root of the Spore SDK:
 
 ```shell
 pnpm i && pnpm run build:packages
@@ -33,16 +27,19 @@ pnpm i && pnpm run build:packages
 
 ### Run an example
 
-> The code of the examples is stored in the [examples/acp/apis](./apis) directory, feel free to review and modify the code, using the examples as your playground or a sandbox to freely experiment.
-
-Assuming your local environment is set up, and you're at the [examples/acp](.) directory, let's run an example to see how things work. 
-For instance, if you want to create a spore on-chain, run the [examples/acp/apis/createAcpCluster.ts](./apis/createAcpCluster.ts) example in your terminal:
+Go to the current directory (`examples/acp`) and run an example:
 
 ```shell
 ts-node apis/createAcpCluster.ts
 ```
 
-This example constructs and sends a transaction that creates a spore on-chain. Once the transaction is sent, a `Transaction Hash` should be returned so that you can review the transaction details on [CKB Explorer](https://pudge.explorer.nervos.org/).
+### Review transaction
+
+This example constructs and sends a transaction that creates a spore on-chain. Once the transaction is sent, a `hash` value should be returned. You can later review the transaction on [CKB Explorer](https://pudge.explorer.nervos.org/):
+
+```shell
+https://pudge.explorer.nervos.org/transaction/{hash}
+```
 
 ## Customization
 
@@ -55,7 +52,7 @@ If you have your own testing accounts, or if you want to configure the SporeConf
 
 ### Use your own accounts
 
-If you want a clean startup environment for testing the functionality of the spore-sdk, you can replace the default testing accounts with your own accounts. Whether locally or in globally, there has two default testing accounts being used, `CHARLIE` and `ALICE`.
+If you want a clean startup environment for testing the functionality of the Spore SDK, you can replace the default testing accounts with your own accounts. Whether locally or in globally, there has two default testing accounts being used, `CHARLIE` and `ALICE`.
 
 How to replace them:
 

--- a/examples/omnilock/README.md
+++ b/examples/omnilock/README.md
@@ -1,20 +1,17 @@
 # Spore Omnilock Examples
 
-## Introduction
+## What is `Omnilock` lock
 
-### What is `Omnilock` lock
+[Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) is a universal and interoperable lock script supporting various blockchains' verification methods (Bitcoin, Ethereum, EOS, etc.) and extensible for future additions. You can create private spores and clusters with it for safeguarding ownership of your assets.
 
-[Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) is an interoperable lock script supporting various blockchains (Bitcoin, Ethereum, EOS, etc.) verification methods and extensible for future additions.
+[Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) also supports a [compatible anyone-can-pay mode](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode), which allows you to create public clusters with the lock script and benefit from charging other users for creating spores within the public cluster. 
 
-It also offers a regulation compliance module for administrator-controlled token revocation, enabling registered assets like Apple stock on CKB when combined with the RCE (Regulation Compliance Extension).
+Please note that [Omnilock ACP](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode) lock differs from the [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock in that it does not allow the minimal CKB or UDT (User-Defined Token) payment amount to be configured as `undefined`. This means that each transaction referencing an Omnilock ACP cell should receive a certain amount of payment.
 
-### Featured examples
+## Featured examples
 
-Spore Omnilock Examples is a collection of code examples where developers can learn how to interact with Omnilock and spore-sdk for various purposes.
-
-In [`/acp`](./acp):
-- Create public clusters with the [Omnilock ACP](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode) lock
-- Create spores in public clusters with the [Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) lock
+- [acp/createAcpCluster.ts](./acp/createAcpCluster.ts): Create a public cluster with the [Omnilock ACP](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode) lock
+- [acp/createSporeInAcpCluster.ts](./acp/createSporeInAcpCluster.ts): Create an [Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) private spore within an [Omnilock ACP](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode) lock cluster
 
 ## Run examples
 
@@ -24,7 +21,7 @@ In [`/acp`](./acp):
 
 ### Setup environment
 
-To set up the local environment, run the following command at the spore-sdk's root directory:
+To set up the local environment, run the following command at the root of the Spore SDK:
 
 ```shell
 pnpm i && pnpm run build:packages
@@ -32,15 +29,19 @@ pnpm i && pnpm run build:packages
 
 ### Run an example
 
-> The code of the examples is stored in the [examples/omnilock/acp](./acp) directory, feel free to review and modify the code, using the examples as your playground or a sandbox to freely experiment.
-
-Assuming your local environment is set up, and you're at the [examples/omnilock](.) directory, let's run an example to see how things work. For instance, if you want to create a cluster with Omnilock as lock with [anyone-can-pay mode](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode) enabled, run the [examples/omnilock/acp/createAcpCluster.ts](./acp/createAcpCluster.ts) example in your terminal:
+Go to the current directory (`examples/omnilock`) and run an example:
 
 ```shell
 ts-node acp/createAcpCluster.ts
 ```
 
-This example constructs and sends a transaction that creates a spore on-chain. Once the transaction is sent, a `Transaction Hash` should be returned so that you can review the transaction details on [CKB Explorer](https://pudge.explorer.nervos.org/).
+### Review transaction
+
+This example constructs and sends a transaction that creates a spore on-chain. Once the transaction is sent, a `hash` value should be returned. You can later review the transaction on [CKB Explorer](https://pudge.explorer.nervos.org/):
+
+```shell
+https://pudge.explorer.nervos.org/transaction/{hash}
+```
 
 ## Customization
 
@@ -53,7 +54,7 @@ If you have your own testing accounts, or if you want to configure the SporeConf
 
 ### Use your own accounts
 
-If you want a clean startup environment for testing the functionality of the spore-sdk, you can replace the default testing accounts with your own accounts. Whether locally or in globally, there has two default testing accounts being used, `CHARLIE` and `ALICE`.
+If you want a clean startup environment for testing the functionality of the Spore SDK, you can replace the default testing accounts with your own accounts. Whether locally or in globally, there has two default testing accounts being used, `CHARLIE` and `ALICE`.
 
 How to replace them:
 

--- a/examples/secp256k1/README.md
+++ b/examples/secp256k1/README.md
@@ -1,18 +1,23 @@
-# Spore Secp256k1 Examples
+# Spore Default Lock Examples
 
 ## Introduction
 
-### What is `Secp256k1Blake160 Sign-all` lock
+### What is `CKB Default Lock`
 
-[Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) is the most widely used lock script on Nervos CKB, or it can even be called as the default lock of Nervos CKB. Users can use the lock to protect their spores/clusters, that if anyone tries to unlock a spore/cluster, a signature must be provided to prove ownership.
+[CKB Default Lock](https://www.notion.so/cryptape/examples/secp256k1) is the most commonly used lock script on [Nervos CKB](https://www.nervos.org/), also a great starting point for beginners due to its simplicity. You can create private spores and clusters with the [CKB Default Lock](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) for safeguarding ownership of your private assets.
+
+[CKB Default Lock](https://www.notion.so/cryptape/examples/secp256k1) is also known as the `Secp256k1Blake160 Sign-all` lock. 
 
 ### Featured examples
 
-The Spore Secp256k1 Examples is a collection of code examples to show developers how to achieve different purposes with Secp256k1Blake160 Sign-all lock and spore-sdk.
+Spore:
+- [apis/createSpore.ts](./apis/createSpore.ts): Create a spore with [CKB Default Lock](https://www.notion.so/cryptape/examples/secp256k1)
+- [apis/transferSpore.ts](./apis/transferSpore.ts): Unlock and transfer a spore from A to B
+- [apis/destroySpore.ts](./apis/destroySpore.ts): Unlock and destroy a spore from the blockchain
 
-In [`/apis`](./apis):
-- Create/transfer clusters with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
-- Create/transfer/destroy spores with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
+Cluster:
+- [apis/createCluster.ts](./apis/createCluster.ts): Create a cluster with [CKB Default Lock](https://www.notion.so/cryptape/examples/secp256k1)
+- [apis/transferSpore.ts](./apis/transferCluster.ts): Unlock and transfer a cluster from A to B
 
 ## Run examples
 
@@ -22,7 +27,7 @@ In [`/apis`](./apis):
 
 ### Setup environment
 
-To set up the local environment, run the following command at the spore-sdk's root directory:
+To set up the local environment, run the following command at the root of the Spore SDK:
 
 ```shell
 pnpm i && pnpm run build:packages
@@ -30,16 +35,19 @@ pnpm i && pnpm run build:packages
 
 ### Run an example
 
-> The code of the examples is stored in the [examples/secp256k1/apis](./apis) directory, feel free to review and modify the code, using the examples as your playground or a sandbox to freely experiment.
-
-Assuming your local environment is set up, and you're at the [examples/secp256k1](.) directory, let's run an example to see how things work. 
-For instance, if you want to create a spore on-chain, run the [examples/secp256k1/apis/createSpore.ts](./apis/createSpore.ts) example in your terminal:
+Go to the current directory (`examples/secp256k1`) and run an example:
 
 ```shell
 ts-node apis/createSpore.ts
 ```
 
-This example constructs and sends a transaction that creates a spore on-chain. Once the transaction is sent, a `Transaction Hash` should be returned so that you can review the transaction details on [CKB Explorer](https://pudge.explorer.nervos.org/).
+### Review transaction
+
+This example constructs and sends a transaction that creates a spore on-chain. Once the transaction is sent, a `hash` value should be returned. You can later review the transaction on [CKB Explorer](https://pudge.explorer.nervos.org/):
+
+```shell
+https://pudge.explorer.nervos.org/transaction/{hash}
+```
 
 ## Customization
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,314 +2,59 @@
 
 ## Features
 
-- Composed APIs to efficiently construct basic spore/cluster transactions, saving more times
-- Joint APIs to merge multiple actions into a single transaction, fun as building blocks
-- Utilities for encoding/decoding data of spores/clusters
-- Designed and implemented based on [Lumos](https://github.com/ckb-js/lumos)
+- ⚡ Composed APIs for efficient spores/clusters interactions with minimal time overhead
+- 🧩 Joint APIs for building advanced transactions as a fun block-building process
+- 🛠️ Utilities for encoding/decoding data of spores/clusters
+- 🎹 Fully written in TypeScript
 
 ## Installation
 
-Install via npm:
+Install `@spore-sdk/core` as a dependency using any package manager, such as `npm`:
 
 ```shell
-npm i @spore-sdk/core
-```
-
-Install via pnpm:
-
-```shell
-pnpm add @spore-sdk/core
-```
-
-Install via yarn:
-
-```shell
-yarn add @spore-sdk/core
+npm install @spore-sdk/core
 ```
 
 ## Getting started
 
-Start using spore-sdk with the `spore-first-example`:
+### Create your first spore in Node.js
 
-https://github.com/sporeprotocol/spore-first-example/blob/0fd0a79fdbfab06c0d11c08011f457986fa85d93/src/index.ts#L4-L20
+Follow the step-by-step tutorial to create your first spore: [Creating your first Spore](https://docs.spore.pro/tutorials/create-first-spore).
 
-Follow the recipes to learn and explore the usage of spore-sdk:
+Or you can run and play with the [spore-first-example](https://github.com/sporeprotocol/spore-first-example) on [StackBlitz](https://stackblitz.com/github/sporeprotocol/spore-first-example?file=src%2Findex.ts&view=editor).
 
-- [Construct transactions with spore-sdk](../../docs/recipes/construct-transaction.md)
+### Follow the recipes
+
+Explore the categorized recipes section in the Spore Docs for detailed instructions: [How-to recipes](https://docs.spore.pro/category/how-to).
+
+Or study the following recipes to explore the usage of the SDK:
+
+- [Construct transactions with Spore SDK](../../docs/recipes/construct-transaction.md)
+
 - [Create immortal spores on-chain](../../docs/recipes/create-immortal-spore.md)
+
 - [Pay fee with capacity margin](../../docs/recipes/capacity-margin.md)
+
 - [Handle spore/cluster data](../../docs/recipes/handle-cell-data.md)
-- [Configure spore-sdk with SporeConfig](../../docs/recipes/configure-spore-config.md)
 
-## Examples
+- [Configure Spore SDK](../../docs/recipes/configure-spore-config.md)
 
-### [@spore-examples/secp256k1](../../examples/secp256k1)
+### Building browser env dapps
 
-Start with the most commonly used lock in Nervos CKB to:
+The Spore SDK is built on top of [Lumos](https://github.com/ckb-js/lumos), an open-source dapp framework for Nervos CKB. Lumos incorporates certain Node-polyfills into its implementation, such as `crypto-browserify` and `buffer`, to provide specific functionalities.
 
-- Create/transfer clusters with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
-- Create/transfer/destroy spores with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
+If you intend to use the Spore SDK in a browser environment, it's important to note that you may need to manually add Node-polyfills to your application. This ensures that the Spore SDK functions properly in the browser. For detailed instructions on how to add these polyfills, refer to the Lumos documentation: [CRA, Vite, Webpack or Other](https://lumos-website.vercel.app/recipes/cra-vite-webpack-or-other).
 
-### [@spore-examples/acp](../../examples/acp)
+## Resources
 
-[Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) (ACP) lock can be unlocked by anyone without signature verification and accepts any amount of CKB or UDT payment from the unlocker.
-Use its flexibility to:
+- [Examples](../../docs/resources/examples.md) - Code block examples for implementing basic and specific features.
+- [Demos](../../docs/resources/demos.md) - Demo applications with full functionality, including seamless integration with wallets.
 
-- Create public clusters with the [Anyone-can-pay](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0026-anyone-can-pay/0026-anyone-can-pay.md) lock
-- Create spores in public clusters with the [Secp256k1Blake160 Sign-all](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c) lock
+## API
 
-### [@spore-examples/omnilock](../../examples/omnilock)
+- [Composed APIs](../../docs/core/composed-apis.md) - APIs for efficient spores/clusters. interactions with minimal time overhead
+- [Joint APIs](../../docs/core/joint-apis.md) - APIs for building advanced transactions as a fun block-building process.
 
-[Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) lock is an interoperable lock script supporting various blockchains (Bitcoin, Ethereum, EOS, etc.) verification methods and extensible for future additions.
-It also offers a regulation compliance module for administrator-controlled token revocation, enabling registered assets like Apple stock on CKB when combined with the RCE (Regulation Compliance Extension).
-Omnilock can be integrated with spore-sdk to:
+## License
 
-- Create public clusters with the [Omnilock ACP](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md#anyone-can-pay-mode) lock
-- Create spores in public clusters with the [Omnilock](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0042-omnilock/0042-omnilock.md) lock
-
-## Composed API
-
-### createSpore
-
-```typescript
-declare function createSpore(props: {
-  data: SporeDataProps;
-  fromInfos: FromInfo[];
-  toLock: Script;
-  config?: SporeConfig;
-  changeAddress?: Address;
-  capacityMargin?: BIish;
-  updateOutput?(cell: Cell): Cell;
-}): Promise<{
-  txSkeleton: helpers.TransactionSkeletonType;
-  outputIndex: number;
-  cluster?: {
-    inputIndex: number;
-    outputIndex: number;
-  };
-}>;
-
-interface SporeDataProps {
-  contentType: string;
-  contentTypeParameters?: EncodableContentType['parameters'];
-  content: BytesLike;
-  clusterId?: HexString;
-}
-```
-
-**Props**
-
-- `data`: Specifies the data of the new spore.
-- `fromInfos`: Specifies where to collect capacity for transaction construction.
-- `toLock`: Specifies the owner of the new spore.
-- `config`: Specifies the config of the SDK.
-- `changeAddress`: Specifies the change cell's ownership.
-- `capacityMargin`: Specifies the capacity margin of the new spore, default to "BI.from(1_0000_0000)".
-- `updateOutput`: Specifies a callback function to update the spore output as needed.
-
-**SporeDataProps**
-
-- `contentType`: MIME of the spore's content, for example: "image/jpeg;a=1;b=2".
-- `contentTypeParameters`: An object of contentType parameters, usually you can pass extension parameters in here, and the object will be merged into contentType during the process of transaction construction. For example if the contentType is "image/jpeg;a=1", and you've passed "{ b: 2 }" in the contentTypeParameters, later the contentType will be modified to "image/jpeg;ext1=true;ext2=true".
-- `content`: The spore's content as bytes, for example if creating a spore where its contentType is "image/jpeg", then its content should be an .jpeg image as bytes.
-- `clusterId`: The spore's cluster ID, should be a 32-byte hash if exists.
-
-**Example**
-
-```typescript
-import { createSpore, predefinedSporeConfigs } from '@spore-sdk/core';
-
-const result = await createSpore({
-  data: {
-    content: JPEG_AS_BYTES,
-    contentType: 'image/jpeg',
-    contentTypeParameters: {
-      ext1: true,
-      ext2: 1,
-    },
-  },
-  fromInfos: [OWNER_ADDRESS],
-  toLock: OWNER_LOCK_SCRIPT,
-  config: predefinedSporeConfigs.Aggron4,
-});
-```
-
-### transferSpore
-
-```typescript
-declare function transferSpore(props: {
-  outPoint: OutPoint;
-  fromInfos: FromInfo[];
-  toLock: Script;
-  config?: SporeConfig;
-  changeAddress?: Address;
-  capacityMargin?: BIish;
-  useCapacityMarginAsFee?: boolean;
-  updateOutput?(cell: Cell): Cell;
-}): Promise<{
-  txSkeleton: helpers.TransactionSkeletonType;
-  inputIndex: number;
-  outputIndex: number;
-}>;
-```
-
-**Props**
-
-- `outPoint`: Specifies a target spore to transfer.
-- `fromInfos`: Specifies where to collect capacity for transaction construction.
-- `toLock`: Specifies the new owner of the spore.
-- `config`: Specifies the config of the SDK.
-- `changeAddress`: Specifies the change cell's ownership.
-- `capacityMargin`: Specifies the capacity margin of the live spore. When "useCapacityMarginAsFee" is true, this prop should not be included in the props.
-- `useCapacityMarginAsFee`: Specifies whether to pay fee with the target spore's capacity margin, if not, the transaction is paid with capacity collected from the fromInfos, default to "true".
-- `updateOutput`: Specifies a callback function to update the target spore output as needed.
-
-**Example**
-
-```typescript
-import { transferSpore, predefinedSporeConfigs } from '@spore-sdk/core';
-
-const result = await transferSpore({
-  outPoint: {
-    txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
-    index: '0x0',
-  },
-  fromInfos: [OWNER_ADDRESS],
-  toLock: RECEIVER_LOCK_SCRIPT,
-  config: predefinedSporeConfigs.Aggron4,
-});
-```
-
-### destroySpore
-
-```typescript
-declare function destroySpore(props: {
-  outPoint: OutPoint;
-  fromInfos: FromInfo[];
-  config?: SporeConfig;
-  changeAddress?: Address;
-}): Promise<{
-  txSkeleton: helpers.TransactionSkeletonType;
-  inputIndex: number;
-}>;
-```
-
-**Props**
-
-- `outPoint`: Specifies a target spore to destroy.
-- `fromInfos`: Specifies where to collect capacity for transaction construction.
-- `config`: Specifies the config of the SDK.
-- `changeAddress`: Specifies the change cell's ownership.
-
-**Example**
-
-```typescript
-import { destroySpore, predefinedSporeConfigs } from '@spore-sdk/core';
-
-const result = await destroySpore({
-  outPoint: {
-    txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
-    index: '0x0',
-  },
-  fromInfos: [OWNER_ADDRESS],
-  config: predefinedSporeConfigs.Aggron4,
-});
-```
-
-### createCluster
-
-```typescript
-declare function createCluster(props: {
-  data: ClusterDataProps;
-  fromInfos: FromInfo[];
-  toLock: Script;
-  config?: SporeConfig;
-  changeAddress?: Address;
-  capacityMargin?: BIish;
-  updateOutput?(cell: Cell): Cell;
-}): Promise<{
-  txSkeleton: helpers.TransactionSkeletonType;
-  outputIndex: number;
-}>;
-
-interface ClusterDataProps {
-  name: string;
-  description: string;
-}
-```
-
-**Props**
-
-- `data`: Specifies the data of the new cluster.
-- `fromInfos`: Specifies where to collect capacity for transaction construction.
-- `toLock`: Specifies the owner of the new cluster.
-- `config`: Specifies the config of the SDK.
-- `changeAddress`: Specifies the change cell's ownership.
-- `capacityMargin`: Specifies the capacity margin of the new cluster, default to "BI.from(1_0000_0000)".
-- `updateOutput`: Specifies a callback function to update the cluster output as needed.
-
-**ClusterDataProps**
-
-- `name`: The name of the new cluster.
-- `description`: The description text of the new cluster.
-
-**Example**
-
-```typescript
-import { createCluster, predefinedSporeConfigs } from '@spore-sdk/core';
-
-const result = await createCluster({
-  data: {
-    name: 'Cluster name',
-    description: 'Description of the cluster',
-  },
-  fromInfos: [OWNER_ADDRESS],
-  toLock: OWNER_LOCK_SCRIPT,
-  config: predefinedSporeConfigs.Aggron4,
-});
-```
-
-### transferCluster
-
-```typescript
-declare function transferCluster(props: {
-  outPoint: OutPoint;
-  fromInfos: FromInfo[];
-  toLock: Script;
-  config?: SporeConfig;
-  changeAddress?: Address;
-  capacityMargin?: BIish;
-  useCapacityMarginAsFee?: boolean;
-  updateOutput?(cell: Cell): Cell;
-}): Promise<{
-  txSkeleton: helpers.TransactionSkeletonType;
-  inputIndex: number;
-  outputIndex: number;
-}>;
-```
-
-**Props**
-
-- `outPoint`: Specifies a target cluster to destroy.
-- `fromInfos`: Specifies where to collect capacity for transaction construction.
-- `config`: Specifies the config of the SDK.
-- `changeAddress`: Specifies the change cell's ownership.
-- `capacityMargin`: Specifies the capacity margin of the live cluster. When "useCapacityMarginAsFee" is true, this prop should not be included in the props.
-- `useCapacityMarginAsFee`: Specifies whether to pay fee with the target cluster cell's capacity margin, if not, the transaction will be paid with capacity collected from the fromInfos, default to "true".
-- `updateOutput`: Specifies a callback function to update the target spore output as needed.
-
-**Example**
-
-```typescript
-import { transferCluster, predefinedSporeConfigs } from '@spore-sdk/core';
-
-const result = await transferCluster({
-  outPoint: {
-    txHash: '0xb1f94d7d8e8441bfdf1fc76639d12f4c3c391b8c8a18ed558e299674095290c3',
-    index: '0x0',
-  },
-  fromInfos: [OWNER_ADDRESS],
-  toLock: RECEIVER_LOCK_SCRIPT,
-  config: predefinedSporeConfigs.Aggron4,
-});
-```
+[MIT](../../LICENSE) License

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -53,7 +53,7 @@ If you intend to use the Spore SDK in a browser environment, it's important to n
 ## API
 
 - [Composed APIs](../../docs/core/composed-apis.md) - APIs for efficient spores/clusters. interactions with minimal time overhead
-- [Joint APIs](../../docs/core/joint-apis.md) - APIs for building advanced transactions as a fun block-building process.
+- [Joint APIs](../../docs/core/joint-apis.md) (WIP) - APIs for building advanced transactions as a fun block-building process.
 
 ## License
 


### PR DESCRIPTION
### Changes
- Refactor `README.md` of root, sdk and examples
- Replace most of "spore-sdk" term to "Spore SDK" to improve readability
- Replace "Secp256k1Blake160 Sign-all Lock" to "CKB Default Lock" to improve readability