### PR TITLE
ref(sdk|examples|docs): rename term from "destroy" to "melt"

### DIFF
--- a/.changeset/little-wolves-shave.md
+++ b/.changeset/little-wolves-shave.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Rename term from "destroy" to "melt", etc. "meltSpore"

--- a/docs/core/composed-apis.md
+++ b/docs/core/composed-apis.md
@@ -111,10 +111,10 @@ const result = await transferSpore({
 });
 ```
 
-### destroySpore
+### meltSpore
 
 ```typescript
-declare function destroySpore(props: {
+declare function meltSpore(props: {
   outPoint: OutPoint;
   fromInfos: FromInfo[];
   config?: SporeConfig;
@@ -135,9 +135,9 @@ declare function destroySpore(props: {
 **Example**
 
 ```typescript
-import { destroySpore, predefinedSporeConfigs } from '@spore-sdk/core';
+import { meltSpore, predefinedSporeConfigs } from '@spore-sdk/core';
 
-const result = await destroySpore({
+const result = await meltSpore({
   outPoint: {
     txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
     index: '0x0',

--- a/docs/recipes/create-immortal-spore.md
+++ b/docs/recipes/create-immortal-spore.md
@@ -5,11 +5,11 @@
 `Immortal` serves as a Spore Extension that offers the following rules:
 
 1. Immortal extension is enabled for a spore if the spore has a `immortal=true` in its `SporeData.contentType`
-2. An immortal spore lives on-chain forever, and cannot be destroyed under any circumstances
+2. An immortal spore lives on-chain forever, and cannot be melted under any circumstances
 
 To create a spore with the immortal extension enabled, you need to pass the `immortal` parameter to the props of the `createSpore` API when calling it. 
 
-Once an immortal spore is successfully created, any attempt from the owner to destroy it will fail due to the verification by the `SporeType` script.
+Once an immortal spore is successfully created, any attempt from the owner to melt it will fail due to the verification by the `SporeType` script.
 
 ## Create immortal spores
 

--- a/docs/resources/demos.md
+++ b/docs/resources/demos.md
@@ -12,7 +12,7 @@ For example, how to connect wallets like [MetaMask](https://metamask.io) or [Joy
 
 ### A simple `Next.js` demo
 
-A Spore Protocol Demo based on Next.js + React + Spore SDK, which implements basic functionalities, such as the creation and transfer of clusters, as well as minting, transferring, and destroying of spores. 
+A Spore Protocol Demo based on Next.js + React + Spore SDK, which implements basic functionalities, such as the creation and transfer of clusters, as well as minting, transferring, and melting of spores. 
 
 The demo also shows how to connect with [MetaMask](https://metamask.io) and [JoyID](https://joy.id) wallets.
 

--- a/examples/secp256k1/README.md
+++ b/examples/secp256k1/README.md
@@ -13,7 +13,7 @@
 Spore:
 - [apis/createSpore.ts](./apis/createSpore.ts): Create a spore with [CKB Default Lock](https://www.notion.so/cryptape/examples/secp256k1)
 - [apis/transferSpore.ts](./apis/transferSpore.ts): Unlock and transfer a spore from A to B
-- [apis/destroySpore.ts](./apis/destroySpore.ts): Unlock and destroy a spore from the blockchain
+- [apis/meltSpore.ts](./apis/meltSpore.ts): Unlock and melt a spore from the blockchain
 
 Cluster:
 - [apis/createCluster.ts](./apis/createCluster.ts): Create a cluster with [CKB Default Lock](https://www.notion.so/cryptape/examples/secp256k1)

--- a/examples/secp256k1/apis/meltSpore.ts
+++ b/examples/secp256k1/apis/meltSpore.ts
@@ -1,10 +1,10 @@
-import { destroySpore } from '@spore-sdk/core';
+import { meltSpore } from '@spore-sdk/core';
 import { accounts, config } from '../utils/config';
 
 (async function main() {
   const { CHARLIE } = accounts;
 
-  let { txSkeleton } = await destroySpore({
+  let { txSkeleton } = await meltSpore({
     outPoint: {
       txHash: '0x3d940aed81a5d336c9dfc30ea1c9a7f5c1e34ab6fa07cddbc82868578c9c23a5',
       index: '0x1',
@@ -14,5 +14,5 @@ import { accounts, config } from '../utils/config';
   });
 
   const hash = await CHARLIE.signAndSendTransaction(txSkeleton);
-  console.log('destroySpore sent, txHash:', hash);
+  console.log('meltSpore sent, txHash:', hash);
 })();

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'vitest';
 import { bytes } from '@ckb-lumos/codec';
 import { OutPoint } from '@ckb-lumos/base';
 import { bytifyRawString } from '../helpers';
-import { createSpore, destroySpore, transferSpore } from '../api';
+import { createSpore, meltSpore, transferSpore } from '../api';
 import { signAndSendTransaction, TESTNET_ACCOUNTS, TESTNET_ENV } from './shared';
 
 const localImage = './resources/test.jpg';
@@ -80,7 +80,7 @@ describe('Spore', function () {
     });
   }, 30000);
 
-  it('Destroy a spore', async function () {
+  it('Melt a spore', async function () {
     const { rpc, config } = TESTNET_ENV;
     const { CHARLIE, ALICE } = TESTNET_ACCOUNTS;
 
@@ -90,7 +90,7 @@ describe('Spore', function () {
     };
 
     // Create cluster cell, collect inputs and pay fee
-    let { txSkeleton } = await destroySpore({
+    let { txSkeleton } = await meltSpore({
       outPoint: outPoint,
       fromInfos: [ALICE.address],
       config,

--- a/packages/core/src/api/composed/spore/meltSpore.ts
+++ b/packages/core/src/api/composed/spore/meltSpore.ts
@@ -5,7 +5,7 @@ import { injectCapacityAndPayFee } from '../../../helpers';
 import { getSporeConfig, SporeConfig } from '../../../config';
 import { getSporeByOutPoint, injectLiveSporeCell } from '../..';
 
-export async function destroySpore(props: {
+export async function meltSpore(props: {
   outPoint: OutPoint;
   fromInfos: FromInfo[];
   config?: SporeConfig;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -3,7 +3,7 @@ export * from './composed/cluster/createCluster';
 export * from './composed/cluster/transferCluster';
 export * from './composed/spore/createSpore';
 export * from './composed/spore/transferSpore';
-export * from './composed/spore/destroySpore';
+export * from './composed/spore/meltSpore';
 
 // Joint APIs
 export * from './joints/cluster/injectNewClusterOutput';

--- a/packages/core/src/extension/extensions/immortal.ts
+++ b/packages/core/src/extension/extensions/immortal.ts
@@ -6,7 +6,7 @@ import { SporeData } from '../../codec';
  * A core extension of Spore NFT, to allow a spore cell to be indestructible on-chain.
  *
  * When setting a spore cell to be "immortal", the spore cell will be indestructible,
- * it cannot be destroyed, therefore the cell can be lived on the blockchain forever.
+ * it cannot be melted, therefore the cell can be lived on the blockchain forever.
  */
 export function useImmortal(): SporeExtension {
   return {
@@ -29,7 +29,7 @@ export function useImmortal(): SporeExtension {
 
         return context.txSkeleton;
       },
-      onDestroySpore(context) {
+      onMeltSpore(context) {
         const outputs = context.txSkeleton.get('outputs');
         const spore = outputs.get(context.inputIndex);
         if (spore) {
@@ -37,7 +37,7 @@ export function useImmortal(): SporeExtension {
           const contentType = decodeContentType(data.contentType);
           if (contentType.parameters.immortal === 'true') {
             throw new Error(
-              `Spore at Transaction.inputs[${context.inputIndex}] cannot be destroyed because it's immortal`,
+              `Spore at Transaction.inputs[${context.inputIndex}] cannot be melted because it's immortal`,
             );
           }
         }

--- a/packages/core/src/extension/types.ts
+++ b/packages/core/src/extension/types.ts
@@ -9,5 +9,5 @@ export interface SporeExtension {
 
 export interface SporeApiHooks {
   onCreateSpore?(context: { txSkeleton: TransactionSkeletonType; outputIndex: number }): TransactionSkeletonType;
-  onDestroySpore?(context: { txSkeleton: TransactionSkeletonType; inputIndex: number }): TransactionSkeletonType;
+  onMeltSpore?(context: { txSkeleton: TransactionSkeletonType; inputIndex: number }): TransactionSkeletonType;
 }


### PR DESCRIPTION
### Changes
- Rename Composed API `destroySpore` to `meltSpore`
- Update the sdk/examples/docs to replace all instances of the mentioned term

### Checklist
- [x] Merge #28 before this
- [x] Change the base branch to `beta`