### PR TITLE
feat(sdk): lock proxy

### DIFF
--- a/.changeset/early-snakes-tan.md
+++ b/.changeset/early-snakes-tan.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Fix typo of the "assertTransactionSkeletonSize" API

--- a/.changeset/small-lobsters-jam.md
+++ b/.changeset/small-lobsters-jam.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Add new spore type script version to support more contract features

--- a/.changeset/three-cows-unite.md
+++ b/.changeset/three-cows-unite.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Support lock proxy in spore creation

--- a/packages/core/src/__tests__/Cluster.test.ts
+++ b/packages/core/src/__tests__/Cluster.test.ts
@@ -11,8 +11,8 @@ describe('Cluster', function () {
     // Create cluster cell, collect inputs and pay fee
     let { txSkeleton } = await createCluster({
       data: {
-        name: 'Testnet Spore 002',
-        description: 'This is a cluster, just for testing.',
+        name: 'Testnet Spore',
+        description: 'This is a testing-only cluster',
       },
       fromInfos: [CHARLIE.address],
       toLock: CHARLIE.lock,

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -1,30 +1,29 @@
 import { describe, it } from 'vitest';
 import { OutPoint } from '@ckb-lumos/base';
-import { createSpore, meltSpore, transferSpore } from '../api';
-import { fetchLocalImage, signAndSendTransaction, TESTNET_ACCOUNTS, TESTNET_ENV } from './shared';
+import { bytifyRawString } from '../helpers';
+import { createSpore, transferSpore, meltSpore } from '../api';
+import { signAndSendTransaction, TESTNET_ACCOUNTS, TESTNET_ENV } from './shared';
 
 describe('Spore', function () {
-  it('Create a spore (no cluster)', async function () {
+  it('Create a spore', async function () {
     const { rpc, config } = TESTNET_ENV;
-    const { CHARLIE } = TESTNET_ACCOUNTS;
-
-    // Generate local image content
-    const content = await fetchLocalImage('./resources/test.jpg', __dirname);
+    const { CHARLIE, ALICE } = TESTNET_ACCOUNTS;
 
     // Create cluster cell, collect inputs and pay fee
     let { txSkeleton } = await createSpore({
       data: {
-        contentType: 'image/jpeg',
-        content: content.arrayBuffer,
+        contentType: 'text/plain',
+        content: bytifyRawString('test spore with cluster'),
+        clusterId: '0x0df701ca5798d381b39435475a17d0c4246d367b5263fe5726098d9ff2f056e0',
       },
-      fromInfos: [CHARLIE.address],
       toLock: CHARLIE.lock,
+      fromInfos: [ALICE.address],
       config,
     });
 
     // Sign and send transaction
     await signAndSendTransaction({
-      account: CHARLIE,
+      account: ALICE,
       txSkeleton,
       config,
       rpc,
@@ -61,7 +60,7 @@ describe('Spore', function () {
 
   it('Melt a spore', async function () {
     const { rpc, config } = TESTNET_ENV;
-    const { CHARLIE, ALICE } = TESTNET_ACCOUNTS;
+    const { ALICE } = TESTNET_ACCOUNTS;
 
     const outPoint: OutPoint = {
       txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
@@ -77,7 +76,7 @@ describe('Spore', function () {
 
     // Sign and send transaction
     await signAndSendTransaction({
-      account: CHARLIE,
+      account: ALICE,
       txSkeleton,
       config,
       rpc,

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -17,13 +17,13 @@ describe('Spore', function () {
         clusterId: '0x0df701ca5798d381b39435475a17d0c4246d367b5263fe5726098d9ff2f056e0',
       },
       toLock: CHARLIE.lock,
-      fromInfos: [ALICE.address],
+      fromInfos: [CHARLIE.address],
       config,
     });
 
     // Sign and send transaction
     await signAndSendTransaction({
-      account: ALICE,
+      account: CHARLIE,
       txSkeleton,
       config,
       rpc,

--- a/packages/core/src/api/composed/cluster/createCluster.ts
+++ b/packages/core/src/api/composed/cluster/createCluster.ts
@@ -3,7 +3,7 @@ import { Address, Script } from '@ckb-lumos/base';
 import { FromInfo } from '@ckb-lumos/common-scripts';
 import { BI, Cell, helpers, Indexer } from '@ckb-lumos/lumos';
 import { getSporeConfig, SporeConfig } from '../../../config';
-import { injectCapacityAndPayFee, assetTransactionSkeletonSize } from '../../../helpers';
+import { injectCapacityAndPayFee, assertTransactionSkeletonSize } from '../../../helpers';
 import { ClusterDataProps, injectNewClusterIds, injectNewClusterOutput } from '../..';
 
 export async function createCluster(props: {
@@ -58,7 +58,7 @@ export async function createCluster(props: {
 
   // Make sure the tx size is in range (if needed)
   if (typeof maxTransactionSize === 'number') {
-    assetTransactionSkeletonSize(txSkeleton, void 0, maxTransactionSize);
+    assertTransactionSkeletonSize(txSkeleton, void 0, maxTransactionSize);
   }
 
   return {

--- a/packages/core/src/api/composed/spore/createSpore.ts
+++ b/packages/core/src/api/composed/spore/createSpore.ts
@@ -6,6 +6,7 @@ import { getSporeConfig, SporeConfig } from '../../../config';
 import { assetTransactionSkeletonSize } from '../../../helpers';
 import { injectCapacityAndPayFee, setAbsoluteCapacityMargin } from '../../../helpers';
 import { injectNewSporeOutput, injectNewSporeIds, SporeDataProps } from '../..';
+import { assetClusteredSporeProof } from '../../joints/spore/injectClusteredSporeProof';
 
 export async function createSpore(props: {
   data: SporeDataProps;
@@ -44,6 +45,8 @@ export async function createSpore(props: {
   const injectNewSporeResult = await injectNewSporeOutput({
     data: props.data,
     toLock: props.toLock,
+    fromInfos: props.fromInfos,
+    changeAddress: props.changeAddress,
     capacityMargin: props.capacityMargin,
     updateOutput(cell) {
       if (capacityMargin.gt(0)) {
@@ -76,6 +79,16 @@ export async function createSpore(props: {
     txSkeleton,
     config,
   });
+
+  // If creating a clustered spore, validate the transaction
+  if (props.data.clusterId !== void 0) {
+    await assetClusteredSporeProof({
+      useLockProxyPattern: injectNewSporeResult.useLockProxyPattern,
+      clusterId: props.data.clusterId,
+      txSkeleton,
+      config,
+    });
+  }
 
   // Make sure the tx size is in range (if needed)
   if (typeof maxTransactionSize === 'number') {

--- a/packages/core/src/api/composed/spore/createSpore.ts
+++ b/packages/core/src/api/composed/spore/createSpore.ts
@@ -6,7 +6,7 @@ import { getSporeConfig, SporeConfig } from '../../../config';
 import { assetTransactionSkeletonSize } from '../../../helpers';
 import { injectCapacityAndPayFee, setAbsoluteCapacityMargin } from '../../../helpers';
 import { injectNewSporeOutput, injectNewSporeIds, SporeDataProps } from '../..';
-import { assetClusteredSporeProof } from '../../joints/spore/injectClusteredSporeProof';
+import { assertClusteredSporeProof } from '../../joints/spore/injectClusteredSporeProof';
 
 export async function createSpore(props: {
   data: SporeDataProps;
@@ -82,8 +82,7 @@ export async function createSpore(props: {
 
   // If creating a clustered spore, validate the transaction
   if (props.data.clusterId !== void 0) {
-    await assetClusteredSporeProof({
-      useLockProxyPattern: injectNewSporeResult.useLockProxyPattern,
+    await assertClusteredSporeProof({
       clusterId: props.data.clusterId,
       txSkeleton,
       config,

--- a/packages/core/src/api/composed/spore/createSpore.ts
+++ b/packages/core/src/api/composed/spore/createSpore.ts
@@ -3,7 +3,7 @@ import { Address, Script } from '@ckb-lumos/base';
 import { FromInfo } from '@ckb-lumos/common-scripts';
 import { BI, Cell, helpers, HexString, Indexer } from '@ckb-lumos/lumos';
 import { getSporeConfig, SporeConfig } from '../../../config';
-import { assetTransactionSkeletonSize } from '../../../helpers';
+import { assertTransactionSkeletonSize } from '../../../helpers';
 import { injectCapacityAndPayFee, setAbsoluteCapacityMargin } from '../../../helpers';
 import { injectNewSporeOutput, injectNewSporeIds, SporeDataProps } from '../..';
 import { assertClusteredSporeProof } from '../../joints/spore/injectClusteredSporeProof';
@@ -91,7 +91,7 @@ export async function createSpore(props: {
 
   // Make sure the tx size is in range (if needed)
   if (typeof maxTransactionSize === 'number') {
-    assetTransactionSkeletonSize(txSkeleton, void 0, maxTransactionSize);
+    assertTransactionSkeletonSize(txSkeleton, void 0, maxTransactionSize);
   }
 
   return {

--- a/packages/core/src/api/joints/spore/injectClusteredSporeProof.ts
+++ b/packages/core/src/api/joints/spore/injectClusteredSporeProof.ts
@@ -1,0 +1,142 @@
+import { BIish } from '@ckb-lumos/bi';
+import { Address, Hash, Script } from '@ckb-lumos/base';
+import { BI, Cell, helpers, HexString } from '@ckb-lumos/lumos';
+import { addCellDep } from '@ckb-lumos/common-scripts/lib/helper';
+import { FromInfo, parseFromInfo } from '@ckb-lumos/common-scripts';
+import { isScriptValueEquals } from '../../../helpers';
+import { getSporeConfig, getSporeScript, SporeConfig } from '../../../config';
+import { injectLiveClusterCell } from '../cluster/injectLiveClusterCell';
+import { getClusterById } from '../cluster/getCluster';
+
+export async function injectClusteredSporeProof(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  clusterId: Hash;
+  toLock: Script;
+  fromInfos: FromInfo[];
+  changeAddress?: Address;
+  cluster?: {
+    updateOutput?(cell: Cell): Cell;
+    capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
+    updateWitness?: HexString | ((witness: HexString) => HexString);
+  };
+  config?: SporeConfig;
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  useLockProxyPattern: boolean;
+  cluster?: {
+    inputIndex: number;
+    outputIndex: number;
+  };
+}> {
+  let txSkeleton = props.txSkeleton;
+  const config = props.config ?? getSporeConfig();
+
+  const cluster = await getClusterById(props.clusterId, config);
+  const clusterLock = cluster.cellOutput.lock;
+
+  const fromInfos = props.fromInfos.map((fromInfo) => {
+    return parseFromInfo(fromInfo, { config: config.lumos });
+  });
+
+  // Check if any sponsor's lock is equals to the cluster's lock,
+  // if it does, Transaction.inputs may contain cells from the specific sponsor.
+  // Note that due to the capacity collection rules, the sdk starts collecting from the first of fromInfos.
+  const isAnyFromInfoEquals = fromInfos.some((fromInfo) => {
+    return isScriptValueEquals(clusterLock, fromInfo.fromScript);
+  });
+
+  // Check if the new spore's lock equals to the cluster's lock,
+  // if it does, Transaction.outputs will contain at least one cell with the same lock as the cluster.
+  const isSporeLockEquals = isScriptValueEquals(clusterLock, props.toLock);
+
+  // Check if the change cell's lock equals to the cluster's lock,
+  // if it does, Transaction.outputs will contain at least one cell with the same lock as the cluster.
+  const firstFromInfo = fromInfos[0];
+  const changeLock = props.changeAddress
+    ? helpers.addressToScript(props.changeAddress, { config: config.lumos })
+    : firstFromInfo.fromScript;
+  const isChangeLockEquals = isScriptValueEquals(clusterLock, changeLock);
+
+  // Apply patterns of lock proxy
+  const useLockProxyPattern = isAnyFromInfoEquals && (isSporeLockEquals || isChangeLockEquals);
+  console.log(isAnyFromInfoEquals, isSporeLockEquals, isChangeLockEquals);
+  console.log(useLockProxyPattern);
+  if (useLockProxyPattern) {
+    const clusterType = cluster.cellOutput.type;
+    const clusterScript = getSporeScript(config, 'Cluster', clusterType);
+    if (!clusterType || !clusterScript) {
+      throw new Error('Cannot inject cluster because target cell is not Cluster');
+    }
+
+    // Add cluster required cellDeps
+    txSkeleton = addCellDep(txSkeleton, clusterScript.cellDep);
+  }
+
+  // Apply normal cluster unlocking rules
+  let injectLiveClusterResult: Awaited<ReturnType<typeof injectLiveClusterCell>> | undefined;
+  if (!useLockProxyPattern) {
+    injectLiveClusterResult = await injectLiveClusterCell({
+      cell: await getClusterById(props.clusterId, config),
+      capacityMargin: props.cluster?.capacityMargin,
+      updateWitness: props.cluster?.updateWitness,
+      updateOutput: props.cluster?.updateOutput,
+      addOutput: true,
+      txSkeleton,
+      config,
+    });
+    txSkeleton = injectLiveClusterResult.txSkeleton;
+
+    // Fix the referenced cluster's output index to prevent it from future reduction
+    txSkeleton = txSkeleton.update('fixedEntries', (fixedEntries) => {
+      return fixedEntries.push({
+        field: 'outputs',
+        index: injectLiveClusterResult!.outputIndex,
+      });
+    });
+  }
+
+  // Add referenced cluster to cellDeps
+  txSkeleton = addCellDep(txSkeleton, {
+    outPoint: cluster.outPoint!,
+    depType: 'code',
+  });
+
+  return {
+    txSkeleton,
+    useLockProxyPattern,
+    cluster: injectLiveClusterResult
+      ? {
+          inputIndex: injectLiveClusterResult.inputIndex,
+          outputIndex: injectLiveClusterResult.outputIndex,
+        }
+      : void 0,
+  };
+}
+
+export async function assetClusteredSporeProof(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  useLockProxyPattern: boolean;
+  clusterId: Hash;
+  config?: SporeConfig;
+}) {
+  let txSkeleton = props.txSkeleton;
+  const config = props.config ?? getSporeConfig();
+  const cluster = await getClusterById(props.clusterId, config);
+  const clusterLock = cluster.cellOutput.lock;
+
+  if (props.useLockProxyPattern) {
+    const foundLockInInputs = txSkeleton.get('inputs').some((cell) => {
+      return isScriptValueEquals(cell.cellOutput.lock, clusterLock);
+    });
+    if (!foundLockInInputs) {
+      throw new Error('Cannot find lock proxy cell in Transaction.inputs');
+    }
+
+    const foundLockInOutputs = txSkeleton.get('outputs').some((cell) => {
+      return isScriptValueEquals(cell.cellOutput.lock, clusterLock);
+    });
+    if (!foundLockInOutputs) {
+      throw new Error('Cannot find lock proxy cell in Transaction.outputs');
+    }
+  }
+}

--- a/packages/core/src/config/predefined.ts
+++ b/packages/core/src/config/predefined.ts
@@ -11,17 +11,31 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
   scripts: {
     Spore: {
       script: {
-        codeHash: '0xbbad126377d45f90a8ee120da988a2d7332c78ba8fd679aab478a19d6c133494',
+        codeHash: '0xf8dd8ff57eb07a78f213b43665fc0f32313acd32f8596f84faa8a01d20d0805f',
         hashType: 'data1',
       },
       cellDep: {
         outPoint: {
-          txHash: '0xfd694382e621f175ddf81ce91ce2ecf8bfc027d53d7d31b8438f7d26fc37fd19',
+          txHash: '0x33042bd2a214d8698939cd5cb1f9d83ab8dfd0b8ef4ddfc21e9fd4a76174576e',
           index: '0x0',
         },
         depType: 'code',
       },
-      versions: [],
+      versions: [
+        {
+          script: {
+            codeHash: '0xbbad126377d45f90a8ee120da988a2d7332c78ba8fd679aab478a19d6c133494',
+            hashType: 'data1',
+          },
+          cellDep: {
+            outPoint: {
+              txHash: '0xfd694382e621f175ddf81ce91ce2ecf8bfc027d53d7d31b8438f7d26fc37fd19',
+              index: '0x0',
+            },
+            depType: 'code',
+          },
+        },
+      ],
     },
     Cluster: {
       script: {

--- a/packages/core/src/helpers/cellDep.ts
+++ b/packages/core/src/helpers/cellDep.ts
@@ -1,0 +1,29 @@
+import { Script } from '@ckb-lumos/base';
+import { helpers, RPC } from '@ckb-lumos/lumos';
+import { getSporeConfig, SporeConfig } from '../config';
+import { getCellWithStatusByOutPoint } from './cell';
+import { isScriptValueEquals } from './script';
+
+export async function findCellDepIndexByTypeFromTransactionSkeleton(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  type: Script;
+  config?: SporeConfig;
+}) {
+  const config = props.config ?? getSporeConfig();
+
+  const rpc = new RPC(config.ckbNodeUrl);
+  const cellDeps = props.txSkeleton.get('cellDeps');
+
+  for await (const [index, cellDep] of cellDeps.toArray().entries()) {
+    const target = await getCellWithStatusByOutPoint({
+      outPoint: cellDep.outPoint,
+      rpc,
+    });
+
+    if (target.cell.cellOutput.type && isScriptValueEquals(target.cell.cellOutput.type, props.type)) {
+      return index;
+    }
+  }
+
+  return -1;
+}

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -3,6 +3,7 @@ export * from './buffer';
 
 // Blockchain
 export * from './cell';
+export * from './cellDep';
 export * from './script';
 export * from './typeId';
 export * from './capacity';

--- a/packages/core/src/helpers/transaction.ts
+++ b/packages/core/src/helpers/transaction.ts
@@ -63,7 +63,7 @@ export function assetTransactionSize(tx: Transaction, min?: number, max?: number
  * Throw an error if the TransactionSkeleton's size (in bytes) is not as expected.
  * Expected: min < size <= max.
  */
-export function assetTransactionSkeletonSize(
+export function assertTransactionSkeletonSize(
   txSkeleton: helpers.TransactionSkeletonType,
   min?: number,
   max?: number,


### PR DESCRIPTION
## Changes
- Support lock proxy in Clustered Spore creation
- Add new SporeType script version to the testnet config

## Features

### Lock proxy

Lock proxy is a set of new rules for creating Clustered Spores (spores with a Cluster ID), which enables users to create Clustered Spores without unlocking/refreshing their clusters in the Spore creation transaction.

With lock proxy, a Clustered Spore creation transaction may look like this:

```yaml
Transaction:
  cellDeps: 
    - Spore Type Script Cell
    - Cluster Type Script Cell
    - Cluster Cell from Charlie
  inputs:
    - Normal Cell(s) from Charlie ...
  outputs:
    - Spore Cell to props.toLock
    - Change Cell to Charlie
```

As comparison, a Clustered Spore creation transaction without lock proxy would look like this:

```yaml
Transaction:
  cellDeps: 
    - Spore Type Script Cell
    - Cluster Type Script Cell
    - Cluster Cell from Charlie
  inputs:
    - Cluster Cell from Charlie
    - Normal Cell(s) from Charlie ...
  outputs:
    - Cluster Cell to Charlie
    - Spore Cell to props.toLock
    - Change Cell to Charlie
```

### New SporeType version

A new version of SporeType script is included in this PR, meaning:

1. New spores will use the new SporeType as type script
2. Existing spores should not be affected, users should still be able to transfer/melt them with spore-sdk