### PR TITLE
feat(sdk): multipart content

### DIFF
--- a/.changeset/polite-donuts-begin.md
+++ b/.changeset/polite-donuts-begin.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Add multipart content support

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,15 +17,16 @@
     "lib"
   ],
   "dependencies": {
-    "@ckb-lumos/bi": "^0.21.0-next.0",
-    "@ckb-lumos/rpc": "^0.21.0-next.0",
     "@ckb-lumos/base": "^0.21.0-next.0",
-    "@ckb-lumos/lumos": "^0.21.0-next.0",
+    "@ckb-lumos/bi": "^0.21.0-next.0",
     "@ckb-lumos/codec": "^0.21.0-next.0",
     "@ckb-lumos/common-scripts": "^0.21.0-next.0",
     "@ckb-lumos/config-manager": "^0.21.0-next.0",
-    "whatwg-mimetype": "^3.0.0",
-    "lodash": "^4.17.21"
+    "@ckb-lumos/lumos": "^0.21.0-next.0",
+    "@ckb-lumos/rpc": "^0.21.0-next.0",
+    "@exact-realty/multipart-parser": "^1.0.9",
+    "lodash": "^4.17.21",
+    "whatwg-mimetype": "^3.0.0"
   },
   "devDependencies": {
     "@types/whatwg-mimetype": "^3.0.0",

--- a/packages/core/src/__tests__/MultipartContent.test.ts
+++ b/packages/core/src/__tests__/MultipartContent.test.ts
@@ -1,0 +1,211 @@
+import { bytes } from '@ckb-lumos/codec';
+import { describe, it, expect } from 'vitest';
+import { TTypedArray } from '@exact-realty/multipart-parser/dist/types';
+import { TDecodedMultipartMessage } from '@exact-realty/multipart-parser/dist/encodeMultipartMessage';
+import { bytifyRawString, decodeMultipartContent, encodeMultipartContent, readArrayBufferStream } from '../helpers';
+import { AsyncableIterable, ResolvedMultipartContent } from '../helpers';
+import { fetchLocalImage } from './shared';
+
+describe('Multipart SporeData.content', async function () {
+  const tests: MultipartTestCase[] = [
+    {
+      raw: `
+--boundary
+content-type: text/plain
+
+a message containing an image
+
+--boundary
+content-disposition: attachment, filename="test.jpg"
+content-transfer-encoding: base64
+content-type: image/jpg
+
+/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAoHBwgHBgoICAgLCgoLDhgQDg0NDh0VFhEYIx8lJCIfIiEmKzcvJik0KSEiMEExNDk7Pj4+JS5ESUM8SDc9Pjv/2wBDAQoLCw4NDhwQEBw7KCIoOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozv/wAARCAAKAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAABAf/xAAfEAADAAICAwEBAAAAAAAAAAABAgMEBQARBiExQRT/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AZHc7XC1vm2wts8x8ds7Y4Ume7H+N0QtAoSepqSzp69ljEAfeUPxO1cnw7S3vV61rr4PSjsWZ2M1JJJ+kn94p9NqqYuRivrMNsfKqbZEjBSlnJBLMOumbsA9n36HExjLGhOEJJKUlCTmihVRQOgAB8AH5wP/Z
+--boundary--
+`,
+      message: [
+        'boundary',
+        [
+          {
+            headers: new Headers({ 'Content-Type': 'text/plain' }),
+            body: bytifyRawString('a message containing an image\r\n'),
+          },
+          {
+            headers: new Headers({
+              'content-type': 'image/jpg',
+              'content-transfer-encoding': 'base64',
+              'content-disposition': 'attachment, filename="test.jpg"',
+            }),
+            body: bytifyRawString((await fetchLocalImage('./resources/test.jpg', __dirname)).base64),
+          },
+        ],
+      ],
+    },
+    {
+      raw: `
+--boundary_1
+content-type: multipart/mixed; boundary=boundary_2
+
+--boundary_2
+content-type: multipart/alternative; boundary=boundary_3
+
+--boundary_3
+content-type: text/plain; charset=UTF-8
+
+Hello,
+
+This is a plain text message.
+
+Best regards,
+Sender
+
+--boundary_3
+content-type: text/html; charset=UTF-8
+
+<html>
+  <body>
+    <p>Hello,</p>
+    <p>This is an HTML message.</p>
+    <p>Best regards,<br>Sender</p>
+  </body>
+</html>
+
+--boundary_3--
+--boundary_2
+content-disposition: attachment; filename="example.dat"
+content-type: image/example
+
+<binary data>
+
+--boundary_2--
+--boundary_1--
+`,
+      message: [
+        'boundary_1',
+        [
+          {
+            headers: new Headers({
+              ['content-type']: 'multipart/mixed; boundary=boundary_2',
+            }),
+            parts: [
+              {
+                headers: new Headers({
+                  'content-type': 'multipart/alternative; boundary=boundary_3',
+                }),
+                parts: [
+                  {
+                    headers: new Headers({
+                      'content-type': 'text/plain; charset=UTF-8',
+                    }),
+                    body: bytifyRawString(
+                      'Hello,\r\n' +
+                        '\r\n' +
+                        'This is a plain text message.\r\n' +
+                        '\r\n' +
+                        'Best regards,\r\n' +
+                        'Sender\r\n',
+                    ),
+                  },
+                  {
+                    headers: new Headers({
+                      'content-type': 'text/html; charset=UTF-8',
+                    }),
+                    body: bytifyRawString(
+                      '<html>\r\n' +
+                        '  <body>\r\n' +
+                        '    <p>Hello,</p>\r\n' +
+                        '    <p>This is an HTML message.</p>\r\n' +
+                        '    <p>Best regards,<br>Sender</p>\r\n' +
+                        '  </body>\r\n' +
+                        '</html>\r\n',
+                    ),
+                  },
+                ],
+              },
+              {
+                headers: new Headers({
+                  'content-disposition': 'attachment; filename="example.dat"',
+                  'content-type': 'image/example',
+                }),
+                body: bytifyRawString('<binary data>\r\n'),
+              },
+            ],
+          },
+        ],
+      ],
+    },
+  ];
+
+  it('Encode', async () => {
+    for (let i = 0; i < tests.length; i++) {
+      const test = tests[i];
+      const encoded = await encodeMultipartContent(...test.message);
+      expect(replaceNewLineToCRLF(encoded.raw)).eq(replaceNewLineToCRLF(test.raw));
+    }
+  });
+
+  it('Decode', async () => {
+    async function testDecoded(
+      msgs: ResolvedMultipartContent[],
+      iterableRefs: AsyncableIterable<TDecodedMultipartMessage>,
+    ) {
+      const refs: TDecodedMultipartMessage[] = [];
+      for await (const ref of iterableRefs) {
+        refs.push(ref);
+      }
+
+      expect(msgs.length).eq(refs.length);
+
+      for (let i = 0; i < msgs.length; i++) {
+        const msg = msgs[i];
+        const ref = refs[i];
+
+        // Headers
+        for (const key of (ref.headers as any).keys()) {
+          expect(msg.headers.get(key)).eq(ref.headers.get(key));
+        }
+        // Body
+        const msgBody = await transformMultipartBody(msg.body);
+        const refBody = await transformMultipartBody(ref.body);
+        expect(bytes.hexify(msgBody)).eq(bytes.hexify(refBody));
+        // Parts
+        if (ref.parts) {
+          expect(!!msg.parts).toBe(true);
+          await testDecoded(msg.parts!, ref.parts);
+        } else {
+          expect(!!msg.parts).toBe(false);
+        }
+      }
+    }
+
+    for (let i = 0; i < tests.length; i++) {
+      const test = tests[i];
+      const messages = await decodeMultipartContent(test.raw, test.message[0]);
+      await testDecoded(messages, test.message[1]);
+    }
+  });
+});
+
+interface MultipartTestCase {
+  raw: string;
+  message: Parameters<typeof encodeMultipartContent>;
+}
+
+async function transformMultipartBody(body: TDecodedMultipartMessage['body']): Promise<ArrayBuffer> {
+  if (body instanceof ArrayBuffer) {
+    return body;
+  } else if (body instanceof Blob) {
+    return await body.arrayBuffer();
+  } else if (body instanceof ReadableStream) {
+    const loaded = await readArrayBufferStream(body);
+    return loaded.buffer;
+  } else if (body?.buffer && (body.buffer as TTypedArray) instanceof ArrayBuffer) {
+    return body.buffer.slice(body.byteOffset, body.byteOffset + body.length);
+  } else {
+    throw new Error('Invalid body type');
+  }
+}
+
+function replaceNewLineToCRLF(str: string) {
+  return str.replace(/(\r\n|\r|\n)/g, '\r\n');
+}

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -1,28 +1,7 @@
-import { resolve } from 'path';
-import { readFileSync } from 'fs';
 import { describe, it } from 'vitest';
-import { bytes } from '@ckb-lumos/codec';
 import { OutPoint } from '@ckb-lumos/base';
-import { bytifyRawString } from '../helpers';
 import { createSpore, meltSpore, transferSpore } from '../api';
-import { signAndSendTransaction, TESTNET_ACCOUNTS, TESTNET_ENV } from './shared';
-
-const localImage = './resources/test.jpg';
-async function fetchInternetImage(src: string) {
-  const res = await fetch(src);
-  return await res.arrayBuffer();
-}
-async function fetchLocalImage(src: string) {
-  const buffer = readFileSync(resolve(__dirname, src));
-  const arrayBuffer = new Uint8Array(buffer).buffer;
-  const base64 = buffer.toString('base64');
-  return {
-    arrayBuffer,
-    arrayBufferHex: bytes.hexify(arrayBuffer),
-    base64,
-    base64Hex: bytes.hexify(bytifyRawString(base64)),
-  };
-}
+import { fetchLocalImage, signAndSendTransaction, TESTNET_ACCOUNTS, TESTNET_ENV } from './shared';
 
 describe('Spore', function () {
   it('Create a spore (no cluster)', async function () {
@@ -30,7 +9,7 @@ describe('Spore', function () {
     const { CHARLIE } = TESTNET_ACCOUNTS;
 
     // Generate local image content
-    const content = await fetchLocalImage(localImage);
+    const content = await fetchLocalImage('./resources/test.jpg', __dirname);
 
     // Create cluster cell, collect inputs and pay fee
     let { txSkeleton } = await createSpore({

--- a/packages/core/src/__tests__/shared/helpers.ts
+++ b/packages/core/src/__tests__/shared/helpers.ts
@@ -1,8 +1,11 @@
-import { hd, helpers, HexString, RPC } from '@ckb-lumos/lumos';
-import { Address, Hash, Script } from '@ckb-lumos/base';
+import { resolve } from 'path';
+import { readFileSync } from 'fs';
+import { bytes } from '@ckb-lumos/codec';
 import { common } from '@ckb-lumos/common-scripts';
+import { Address, Hash, Script } from '@ckb-lumos/base';
+import { hd, helpers, HexString, RPC } from '@ckb-lumos/lumos';
+import { bytifyRawString, createCapacitySnapshot, defaultEmptyWitnessArgs, updateWitnessArgs } from '../../helpers';
 import { SporeConfig } from '../../config';
-import { createCapacitySnapshot, defaultEmptyWitnessArgs, updateWitnessArgs } from '../../helpers';
 
 export interface TestAccount {
   lock: Script;
@@ -101,4 +104,29 @@ export async function signAndSendTransaction(props: {
   }
 
   return hash;
+}
+
+export async function fetchLocalImage(
+  src: string,
+  relativePath?: string,
+): Promise<{
+  arrayBuffer: ArrayBuffer;
+  arrayBufferHex: HexString;
+  base64: string;
+  base64Hex: HexString;
+}> {
+  const buffer = readFileSync(resolve(relativePath ?? __dirname, src));
+  const arrayBuffer = new Uint8Array(buffer).buffer;
+  const base64 = buffer.toString('base64');
+  return {
+    arrayBuffer,
+    arrayBufferHex: bytes.hexify(arrayBuffer),
+    base64,
+    base64Hex: bytes.hexify(bytifyRawString(base64)),
+  };
+}
+
+export async function fetchInternetImage(src: string): Promise<ArrayBuffer> {
+  const res = await fetch(src);
+  return await res.arrayBuffer();
 }

--- a/packages/core/src/helpers/buffer.ts
+++ b/packages/core/src/helpers/buffer.ts
@@ -1,18 +1,13 @@
 import { bytes, BytesLike } from '@ckb-lumos/codec';
 
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
 export function bytifyRawString(text: string): Uint8Array {
-  if (typeof window !== 'undefined' && 'TextEncoder' in window) {
-    return new TextEncoder().encode(text);
-  } else {
-    return Uint8Array.from(Buffer.from(text, 'utf-8'));
-  }
+  return encoder.encode(text);
 }
 
-export function bufferToRawString(source: BytesLike): string {
+export function bufferToRawString(source: BytesLike, options?: TextDecodeOptions): string {
   const buffer = bytes.bytify(source);
-  if (typeof window !== 'undefined' && 'TextDecoder' in window) {
-    return new TextDecoder().decode(buffer);
-  } else {
-    return Buffer.from(buffer).toString();
-  }
+  return decoder.decode(buffer, options);
 }

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -12,3 +12,4 @@ export * from './fee';
 
 // Core
 export * from './contentType';
+export * from './multipartContent';

--- a/packages/core/src/helpers/multipartContent.ts
+++ b/packages/core/src/helpers/multipartContent.ts
@@ -1,0 +1,90 @@
+import { bytes, BytesLike } from '@ckb-lumos/codec';
+import parseMultipartMessage, { encodeMultipartMessage } from '@exact-realty/multipart-parser';
+import { TDecodedMultipartMessage } from '@exact-realty/multipart-parser/dist/encodeMultipartMessage';
+import { TMultipartMessageGenerator } from '@exact-realty/multipart-parser/dist/parseMultipartMessage';
+import { TTypedArray } from '@exact-realty/multipart-parser/dist/types';
+import { bufferToRawString, bytifyRawString } from './buffer';
+
+export type AsyncableIterable<T> = AsyncIterable<T> | Iterable<T>;
+
+export type ResolvedMultipartContent = {
+  headers: Headers;
+  body?: Uint8Array | null;
+  parts?: ResolvedMultipartContent[] | null;
+};
+
+export async function decodeMultipartContent(message: string, boundary: string): Promise<ResolvedMultipartContent[]> {
+  const buf = bytifyRawString(replaceNewLineToCRLF(message));
+  return decodeMultipartContentFromBytes(buf, boundary);
+}
+
+export async function decodeMultipartContentFromBytes(
+  buf: BytesLike,
+  boundary: string,
+): Promise<ResolvedMultipartContent[]> {
+  const stream = new Blob([bytes.bytify(buf)]).stream();
+  return decodeMultipartContentFromStream(stream, boundary);
+}
+
+export async function decodeMultipartContentFromStream<T extends TTypedArray>(
+  stream: ReadableStream<T>,
+  boundary: string,
+): Promise<ResolvedMultipartContent[]> {
+  async function parseMimeRecursively(messages: TMultipartMessageGenerator): Promise<ResolvedMultipartContent[]> {
+    const chunks: ResolvedMultipartContent[] = [];
+    for await (const chunk of messages) {
+      if (chunk.parts) {
+        const parts = await parseMimeRecursively(chunk.parts);
+        chunks.push({
+          ...chunk,
+          parts,
+        });
+      } else {
+        chunks.push({
+          headers: chunk.headers,
+          body: chunk.body,
+        });
+      }
+    }
+
+    return chunks;
+  }
+
+  return parseMimeRecursively(parseMultipartMessage(stream, boundary));
+}
+
+export async function encodeMultipartContent(
+  boundary: string,
+  msg: AsyncableIterable<TDecodedMultipartMessage>,
+): Promise<{ buffer: ArrayBuffer; raw: string }> {
+  const encoded = encodeMultipartMessage(boundary, msg);
+  return await readArrayBufferStream(encoded);
+}
+
+export async function readArrayBufferStream(stream: ReadableStream<ArrayBuffer>): Promise<{
+  buffer: ArrayBuffer;
+  raw: string;
+}> {
+  const reader = stream.getReader();
+  const buffers: ArrayBuffer[] = [];
+
+  while (true) {
+    const chunk = await reader.read();
+    if (!chunk.done) {
+      buffers.push(chunk.value);
+    } else {
+      break;
+    }
+  }
+
+  const buf = await new Blob(buffers).arrayBuffer();
+
+  return {
+    buffer: buf,
+    raw: bufferToRawString(buf),
+  };
+}
+
+function replaceNewLineToCRLF(str: string) {
+  return str.replace(/\r(?!n)|(?<!\r)\n/g, '\r\n');
+}

--- a/packages/core/src/helpers/multipartContent.ts
+++ b/packages/core/src/helpers/multipartContent.ts
@@ -66,11 +66,11 @@ export async function encodeMultipartContent(
   codeUnitLength: number;
 }> {
   const stream = encodeMultipartMessage(boundary, message);
-  const buffer = await readArrayBufferStream(stream);
+  const result = await readArrayBufferStream(stream);
 
   return {
     stream,
-    ...buffer,
+    ...result,
   };
 }
 
@@ -110,6 +110,24 @@ export async function readArrayBufferStream(stream: ReadableStream<ArrayBuffer>)
     byteLength,
     codeUnitLength,
   };
+}
+
+export async function isMultipartContentValid(message: string, boundary: string): Promise<boolean> {
+  try {
+    await decodeMultipartContent(message, boundary);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isMultipartContentAsBytesValid(buf: BytesLike, boundary: string): Promise<boolean> {
+  try {
+    await decodeMultipartContentFromBytes(buf, boundary);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function replaceNewLineToCRLF(str: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@ckb-lumos/rpc':
         specifier: ^0.21.0-next.0
         version: 0.21.0-next.0(cross-fetch@3.1.8)(jsbi@4.3.0)
+      '@exact-realty/multipart-parser':
+        specifier: ^1.0.9
+        version: 1.0.9
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -750,6 +753,11 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@exact-realty/multipart-parser@1.0.9:
+    resolution: {integrity: sha512-XU2qKFDWdds1TADn6GBvFcue+W5xAwu2pQq0zBLK5GiQrzILWo/NTrboyw2vuMbu1GLKgLqEtJOXmUvrx2JjVA==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    dev: false
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}


### PR DESCRIPTION
## Changes
- Add multipart content relevant utilities/tests
  - Utilities: `encodeMultipartContent`, `decodeMultipartContent`  
  - Tests: `MultipartContent.test.ts`

## Features

### Multipart content

This is a MIME implementation that enables users to put multiple formats of data into one `SporeData.content`.

A simple example of multipart content in spore:

SporeData.contentType

```
multipart/mixed;boundary="simple boundary"
```

SporeData.content

```
This is the preamble.  It is to be ignored, though it is a handy place for mail composers to include an explanatory note to non-MIME compliant readers. 
--simple boundary 

This is implicitly typed plain ASCII text. It does NOT end with a linebreak. 
--simple boundary 
Content-type: text/plain; charset=us-ascii 

This is explicitly typed plain ASCII text. It DOES end with a linebreak. 

--simple boundary-- 
This is the epilogue.  It is also to be ignored.
```

## Reference
- https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
- https://www.ietf.org/rfc/rfc2046.html#section-5.1




