### PR TITLE
bump(sdk): 0.1.0-beta.13

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -10,6 +10,7 @@
     "fuzzy-worms-give",
     "gold-eggs-attend",
     "honest-masks-join",
+    "little-wolves-shave",
     "modern-kids-clean",
     "popular-coins-mix",
     "popular-ears-thank",
@@ -21,6 +22,7 @@
     "sweet-snails-compare",
     "tasty-boats-obey",
     "thirty-shoes-own",
+    "wet-deers-behave",
     "yellow-flies-play"
   ]
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @spore-sdk/core
 
+## 0.1.0-beta.13
+
+### Patch Changes
+
+- bc37376: Rename term from "destroy" to "melt", etc. "meltSpore"
+- 9f1d792: Rename Joint APIs, from "getXCellByY" to "getXByY", and from "injectXIds" to "injectNewXIds"
+
 ## 0.1.0-beta.12
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spore-sdk/core",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "license": "MIT",
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
### Change log
- bc37376: Rename term from "destroy" to "melt", etc. "meltSpore"
- 9f1d792: Rename Joint APIs, from "getXCellByY" to "getXByY", and from "injectXIds" to "injectNewXIds"

### Including PRs
- #26
- #28
- #29 
- #35