### PR TITLE
chore: add release/test workflows for github ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# Release packages to NPM and GitHub.
+
+name: Release
+
+on:
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm run release:packages
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,43 @@
+# Test the functionality of the packages.
+
+name: Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        run: pnpm run test:packages

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean:examples": "turbo run clean --filter=./examples/*",
     "clean:dependencies": "pnpm clean:sub-dependencies && rimraf node_modules",
     "clean:sub-dependencies": "rimraf packages/**/node_modules examples/**/node_modules",
-    "release:packages": "pnpm run clean:packages && pnpm run build:packages && changeset version && changeset publish"
+    "release:packages": "pnpm run clean:packages && pnpm run build:packages && changeset publish"
   },
   "dependencies": {
     "rimraf": "^5.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,9 +36,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShookLyngs/spore-sdk.git"
+    "url": "git+https://github.com/sporeprotocol/spore-sdk.git"
   },
   "bugs": {
-    "url": "https://github.com/ShookLyngs/spore-sdk/issues"
+    "url": "https://github.com/sporeprotocol/spore-sdk/issues"
   }
 }


### PR DESCRIPTION
### Changes
- Add `release` workflow to publish packages in a clean environment instead of locally
- Add `test` workflow to test the features of the packages in pull requests
- Fix and update `package.json` info of root and the core package

### Relevant todos

- [x] Set `NPM_TOKEN`
- [x] Set `GITHUB_TOKEN`


### Extras

#### The turbo issue

@ahonn reported that after the `pnpm run build:packages` command, the `lib` folder only contains a few files instead of the full expected content. I identified that the issue was related to the malfunctioning of `turbo run`. The problem was resolved after I cleared the repository cache. 

To prevent this from happening again, I have created the `release` workflow. Running it in the GitHub CI (a clean environment) should help prevent such issues. When a bump commit has been merged, we can trigger the `release` workflow manually.

#### Disable `test` by default

The `test` workflow should fail at this point because not all tests are ready to run in automation. Therefore, I believe the `test` workflow should be disabled by default until the tests are well organized/updated.