### PR TITLE
fix(sdk): spore/cluster id validation

### DIFF
--- a/.changeset/itchy-plants-kick.md
+++ b/.changeset/itchy-plants-kick.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Fix spore/cluster query logic, should validate target id before querying

--- a/packages/core/src/api/joints/cluster/getCluster.ts
+++ b/packages/core/src/api/joints/cluster/getCluster.ts
@@ -1,12 +1,17 @@
 import { OutPoint, Script } from '@ckb-lumos/base';
 import { Cell, HexString, Indexer, RPC } from '@ckb-lumos/lumos';
-import { getCellByType, getCellWithStatusByOutPoint } from '../../../helpers';
+import { getCellByType, getCellWithStatusByOutPoint, isTypeId } from '../../../helpers';
 import { getSporeConfig, getSporeScript, isSporeScriptSupportedByName, SporeConfig } from '../../../config';
 
 export async function getClusterByType(type: Script, config?: SporeConfig): Promise<Cell> {
   // Env
   config = config ?? getSporeConfig();
   const indexer = new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl);
+
+  // Check if the cluster's id is TypeID
+  if (!isTypeId(type.args)) {
+    throw new Error(`Target Cluster Id is invalid: ${type.args}`);
+  }
 
   // Get cell by type
   const cell = await getCellByType({ type, indexer });
@@ -50,7 +55,12 @@ export async function getClusterById(id: HexString, config?: SporeConfig): Promi
   // Env
   config = config ?? getSporeConfig();
 
-  // Get cluster versioned script
+  // Check if the cluster's id is TypeID
+  if (!isTypeId(id)) {
+    throw new Error(`Target ClusterId is invalid: ${id}`);
+  }
+
+  // Get cluster script
   const clusterScript = getSporeScript(config, 'Cluster');
   const versionScripts = (clusterScript.versions ?? []).map((r) => r.script);
   const scripts = [clusterScript.script, ...versionScripts];

--- a/packages/core/src/api/joints/spore/getSpore.ts
+++ b/packages/core/src/api/joints/spore/getSpore.ts
@@ -1,12 +1,17 @@
 import { OutPoint, Script } from '@ckb-lumos/base';
 import { Cell, HexString, Indexer, RPC } from '@ckb-lumos/lumos';
-import { getCellByType, getCellWithStatusByOutPoint } from '../../../helpers';
+import { getCellByType, getCellWithStatusByOutPoint, isTypeId } from '../../../helpers';
 import { getSporeConfig, getSporeScript, isSporeScriptSupportedByName, SporeConfig } from '../../../config';
 
 export async function getSporeByType(type: Script, config?: SporeConfig): Promise<Cell> {
   // Env
   config = config ?? getSporeConfig();
   const indexer = new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl);
+
+  // Check if the spore's id is TypeID
+  if (!isTypeId(type.args)) {
+    throw new Error(`Target Spore ID is invalid: ${type.args}`);
+  }
 
   // Get cell by type
   const cell = await getCellByType({ type, indexer });
@@ -46,6 +51,11 @@ export async function getSporeByOutPoint(outPoint: OutPoint, config?: SporeConfi
 export async function getSporeById(id: HexString, config?: SporeConfig): Promise<Cell> {
   // Env
   config = config ?? getSporeConfig();
+
+  // Check if the spore's id is TypeID
+  if (!isTypeId(id)) {
+    throw new Error('Cannot find spore because target SporeId is not valid');
+  }
 
   // Get SporeType script
   const sporeScript = getSporeScript(config, 'Spore');

--- a/packages/core/src/helpers/typeId.ts
+++ b/packages/core/src/helpers/typeId.ts
@@ -1,6 +1,7 @@
-import { BI, Cell, utils } from '@ckb-lumos/lumos';
 import { BIish } from '@ckb-lumos/bi';
 import { Hash } from '@ckb-lumos/base';
+import { BI, Cell, utils } from '@ckb-lumos/lumos';
+import { bytes, BytesLike } from '@ckb-lumos/codec';
 
 /**
  * Generate a TypeId based on the first input in Transaction.inputs,
@@ -67,4 +68,28 @@ export function generateTypeIdsByOutputs(
   }
 
   return result;
+}
+
+/**
+ * Check if the target string is a Type ID
+ */
+export function isTypeId(target: BytesLike): boolean {
+  try {
+    const buf = bytes.bytify(target);
+    return buf.byteLength === 32;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if the target string at least contains is a Type ID
+ */
+export function isTypeIdLengthMatch(target: BytesLike): boolean {
+  try {
+    const buf = bytes.bytify(target);
+    return buf.byteLength >= 32;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
### Changes
- Add utilities to check if a string is TypeId (only checks its length)
- Resolves #27 