### PR TITLE
feat(sdk|examples|docs): Remove "fromInfos" prop from the meltSpore API

### DIFF
--- a/.changeset/old-oranges-invite.md
+++ b/.changeset/old-oranges-invite.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Remove "fromInfos" prop from the "meltSpore" API

--- a/.changeset/stale-ghosts-lie.md
+++ b/.changeset/stale-ghosts-lie.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Fix and optimize the logic of capacity collection

--- a/docs/core/composed-apis.md
+++ b/docs/core/composed-apis.md
@@ -116,9 +116,8 @@ const result = await transferSpore({
 ```typescript
 declare function meltSpore(props: {
   outPoint: OutPoint;
-  fromInfos: FromInfo[];
-  config?: SporeConfig;
   changeAddress?: Address;
+  config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
   inputIndex: number;
@@ -128,9 +127,8 @@ declare function meltSpore(props: {
 **Props**
 
 - `outPoint`: Specifies a target spore to melt, which is identified by its index from a specific Transaction.outputs.
-- `fromInfos`: Specifies where to collect capacity for transaction construction.
-- `config`: Specifies the config of the SDK.
 - `changeAddress`: Specifies the change cell's ownership.
+- `config`: Specifies the config of the SDK.
 
 **Example**
 
@@ -142,7 +140,7 @@ const result = await meltSpore({
     txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
     index: '0x0',
   },
-  fromInfos: [OWNER_ADDRESS],
+  changeAddress: OWNER_ADDRESS,
   config: predefinedSporeConfigs.Aggron4,
 });
 ```

--- a/examples/secp256k1/apis/meltSpore.ts
+++ b/examples/secp256k1/apis/meltSpore.ts
@@ -9,7 +9,7 @@ import { accounts, config } from '../utils/config';
       txHash: '0x3d940aed81a5d336c9dfc30ea1c9a7f5c1e34ab6fa07cddbc82868578c9c23a5',
       index: '0x1',
     },
-    fromInfos: [CHARLIE.address],
+    changeAddress: CHARLIE.address,
     config,
   });
 

--- a/packages/core/src/__tests__/Capacity.test.ts
+++ b/packages/core/src/__tests__/Capacity.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { Cell } from '@ckb-lumos/base';
+import { BI, helpers } from '@ckb-lumos/lumos';
+import { common } from '@ckb-lumos/common-scripts';
+import { TESTNET_ACCOUNTS, TESTNET_ENV } from './shared';
+import {
+  getMinFeeRate,
+  calculateFeeByTransactionSkeleton,
+  createCapacitySnapshotFromTransactionSkeleton,
+  injectCapacityAndPayFee,
+  returnExceededCapacity,
+  payFeeByOutput,
+} from '../helpers';
+
+describe('Capacity', function () {
+  const { CHARLIE } = TESTNET_ACCOUNTS;
+  const { config, rpc, indexer } = TESTNET_ENV;
+
+  it('Normal capacity collection', async () => {
+    let txSkeleton = new helpers.TransactionSkeleton({
+      cellProvider: indexer,
+    });
+
+    txSkeleton = txSkeleton.update('outputs', (outputs) => {
+      return outputs.push({
+        cellOutput: {
+          capacity: BI.from(100_0000_0000).toHexString(),
+          lock: CHARLIE.lock,
+        },
+        data: '0x',
+      });
+    });
+
+    txSkeleton = txSkeleton.update('fixedEntries', (fixedEntries) => {
+      return fixedEntries.push({
+        field: 'outputs',
+        index: 0,
+      });
+    });
+
+    const injected = await injectCapacityAndPayFee({
+      fromInfos: [CHARLIE.address],
+      txSkeleton,
+      config,
+    });
+
+    txSkeleton = injected.txSkeleton;
+    const { before: beforeSnap, after: afterSnap } = injected;
+    expect(afterSnap.inputsLength - beforeSnap.inputsLength).gte(1, 'should have collected >= 1 input');
+    expect(afterSnap.outputsLength - beforeSnap.outputsLength).gte(1, 'should have generated a change cell');
+
+    const feeRate = await getMinFeeRate(rpc);
+    const fee = calculateFeeByTransactionSkeleton(txSkeleton, feeRate);
+    expect(afterSnap.inputsRemainCapacity.eq(fee)).eq(true, 'should have paid the exact amount of fee');
+  }, 30000);
+
+  it('No capacity collection, only returning exceeded capacity', async () => {
+    let txSkeleton = new helpers.TransactionSkeleton({
+      cellProvider: indexer,
+    });
+
+    const expectCapacity = BI.from(100_0000_0000).toHexString();
+    const collector = indexer.collector({
+      lock: CHARLIE.lock,
+      outputDataLenRange: ['0x0', '0x1'],
+    });
+
+    let collectedCell: Cell | undefined;
+    let collectedCapacity: BI | undefined;
+    for await (const cell of collector.collect()) {
+      collectedCapacity = BI.from(cell.cellOutput.capacity);
+      collectedCell = cell;
+      break;
+    }
+    expect(collectedCell).toBeDefined();
+    expect(collectedCapacity).toBeDefined();
+
+    // Add cell to inputs and outputs,
+    // and then remove the cell from outputs because not needed
+    txSkeleton = await common.setupInputCell(txSkeleton, collectedCell!, CHARLIE.address, {
+      config: config.lumos,
+    });
+    txSkeleton = txSkeleton.update('outputs', (outputs) => {
+      return outputs.remove(0);
+    });
+    expect(txSkeleton.get('inputs').size).eq(1, 'should have 1 input');
+    expect(txSkeleton.get('outputs').size).eq(0, 'should have 0 output');
+
+    const returned = returnExceededCapacity({
+      changeAddress: CHARLIE.address,
+      config: config.lumos,
+      txSkeleton,
+    });
+
+    txSkeleton = returned.txSkeleton;
+    expect(returned.returnedChange).eq(true, 'should have returned change');
+    expect(returned.createdChangeCell).eq(true, 'should have created a change cell');
+    expect(returned.changeCellOutputIndex).eq(0, 'should have created the change cell at index 0');
+
+    const snapshot = createCapacitySnapshotFromTransactionSkeleton(txSkeleton);
+    expect(snapshot.outputsCapacity.eq(collectedCapacity!)).eq(
+      true,
+      'outputs capacity should be equal to collected capacity',
+    );
+    expect(snapshot.inputsRemainCapacity.eq(0)).eq(true, 'inputs and outputs capacity should be even');
+
+    const feeRate = await getMinFeeRate(rpc);
+    const fee = calculateFeeByTransactionSkeleton(txSkeleton, feeRate);
+    txSkeleton = await payFeeByOutput({
+      outputIndex: 0,
+      txSkeleton,
+      config,
+    });
+
+    const paidSnap = createCapacitySnapshotFromTransactionSkeleton(txSkeleton);
+    expect(paidSnap.inputsRemainCapacity.eq(fee)).eq(true, 'should have paid the exact amount of fee');
+  });
+});

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -64,14 +64,14 @@ describe('Spore', function () {
     const { CHARLIE, ALICE } = TESTNET_ACCOUNTS;
 
     const outPoint: OutPoint = {
-      txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
+      txHash: '0x8ef248af053927c04e892c6d1e20eb5c0f112d2fb54777291c136b6ed0f776bd',
       index: '0x0',
     };
 
     // Create cluster cell, collect inputs and pay fee
     let { txSkeleton } = await meltSpore({
       outPoint: outPoint,
-      fromInfos: [ALICE.address],
+      changeAddress: ALICE.address,
       config,
     });
 

--- a/packages/core/src/__tests__/shared/helpers.ts
+++ b/packages/core/src/__tests__/shared/helpers.ts
@@ -4,8 +4,10 @@ import { bytes } from '@ckb-lumos/codec';
 import { common } from '@ckb-lumos/common-scripts';
 import { Address, Hash, Script } from '@ckb-lumos/base';
 import { hd, helpers, HexString, RPC } from '@ckb-lumos/lumos';
-import { bytifyRawString, createCapacitySnapshot, defaultEmptyWitnessArgs, updateWitnessArgs } from '../../helpers';
 import { SporeConfig } from '../../config';
+import { bytifyRawString } from '../../helpers';
+import { defaultEmptyWitnessArgs, updateWitnessArgs } from '../../helpers';
+import { createCapacitySnapshotFromTransactionSkeleton } from '../../helpers';
 
 export interface TestAccount {
   lock: Script;
@@ -83,7 +85,7 @@ export async function signAndSendTransaction(props: {
   txSkeleton = common.prepareSigningEntries(txSkeleton, { config: config.lumos });
   txSkeleton = account.signTransaction(txSkeleton);
   if (debug) {
-    const snap = createCapacitySnapshot(txSkeleton.get('inputs').toArray(), txSkeleton.get('outputs').toArray());
+    const snap = createCapacitySnapshotFromTransactionSkeleton(txSkeleton);
     console.log('inputsCapacity', snap.inputsCapacity.toString());
     console.log('outputsCapacity', snap.outputsCapacity.toString());
   }

--- a/packages/core/src/api/composed/cluster/createCluster.ts
+++ b/packages/core/src/api/composed/cluster/createCluster.ts
@@ -44,7 +44,6 @@ export async function createCluster(props: {
     txSkeleton,
     changeAddress: props.changeAddress,
     fromInfos: props.fromInfos,
-    fee: BI.from(0),
     config,
   });
   txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;

--- a/packages/core/src/api/composed/cluster/transferCluster.ts
+++ b/packages/core/src/api/composed/cluster/transferCluster.ts
@@ -66,7 +66,6 @@ export async function transferCluster(props: {
       txSkeleton,
       changeAddress: props.changeAddress,
       fromInfos: props.fromInfos!,
-      fee: BI.from(0),
       config,
     });
     txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;

--- a/packages/core/src/api/composed/spore/createSpore.ts
+++ b/packages/core/src/api/composed/spore/createSpore.ts
@@ -65,7 +65,6 @@ export async function createSpore(props: {
     txSkeleton,
     changeAddress: props.changeAddress,
     fromInfos: props.fromInfos,
-    fee: BI.from(0),
     config,
   });
   txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;

--- a/packages/core/src/api/composed/spore/meltSpore.ts
+++ b/packages/core/src/api/composed/spore/meltSpore.ts
@@ -1,13 +1,11 @@
 import { Address, OutPoint } from '@ckb-lumos/base';
-import { FromInfo } from '@ckb-lumos/common-scripts';
 import { helpers, HexString, Indexer } from '@ckb-lumos/lumos';
-import { injectCapacityAndPayFee } from '../../../helpers';
+import { returnExceededCapacityAndPayFee } from '../../../helpers';
 import { getSporeConfig, SporeConfig } from '../../../config';
 import { getSporeByOutPoint, injectLiveSporeCell } from '../..';
 
 export async function meltSpore(props: {
   outPoint: OutPoint;
-  fromInfos: FromInfo[];
   config?: SporeConfig;
   changeAddress?: Address;
   updateWitness?: HexString | ((witness: HexString) => HexString);
@@ -25,22 +23,23 @@ export async function meltSpore(props: {
   });
 
   // Inject live spore to Transaction.inputs
+  const spore = await getSporeByOutPoint(props.outPoint, config);
   const injectLiveSporeCellResult = await injectLiveSporeCell({
-    cell: await getSporeByOutPoint(props.outPoint, config),
     updateWitness: props.updateWitness,
+    cell: spore,
     txSkeleton,
     config,
   });
   txSkeleton = injectLiveSporeCellResult.txSkeleton;
 
-  // Inject needed capacity and pay fee
-  const injectCapacityAndPayFeeResult = await injectCapacityAndPayFee({
-    changeAddress: props.changeAddress,
-    fromInfos: props.fromInfos,
+  // Redeem capacity from the melted spore
+  const sporeAddress = helpers.encodeToAddress(spore.cellOutput.lock, { config: config.lumos });
+  const returnExceededCapacityAndPayFeeResult = await returnExceededCapacityAndPayFee({
+    changeAddress: props.changeAddress ?? sporeAddress,
     txSkeleton,
     config,
   });
-  txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;
+  txSkeleton = returnExceededCapacityAndPayFeeResult.txSkeleton;
 
   return {
     txSkeleton,

--- a/packages/core/src/api/composed/spore/meltSpore.ts
+++ b/packages/core/src/api/composed/spore/meltSpore.ts
@@ -1,6 +1,6 @@
 import { Address, OutPoint } from '@ckb-lumos/base';
 import { FromInfo } from '@ckb-lumos/common-scripts';
-import { BI, helpers, HexString, Indexer } from '@ckb-lumos/lumos';
+import { helpers, HexString, Indexer } from '@ckb-lumos/lumos';
 import { injectCapacityAndPayFee } from '../../../helpers';
 import { getSporeConfig, SporeConfig } from '../../../config';
 import { getSporeByOutPoint, injectLiveSporeCell } from '../..';
@@ -25,9 +25,8 @@ export async function meltSpore(props: {
   });
 
   // Inject live spore to Transaction.inputs
-  const sporeCell = await getSporeByOutPoint(props.outPoint, config);
   const injectLiveSporeCellResult = await injectLiveSporeCell({
-    cell: sporeCell,
+    cell: await getSporeByOutPoint(props.outPoint, config),
     updateWitness: props.updateWitness,
     txSkeleton,
     config,
@@ -36,10 +35,9 @@ export async function meltSpore(props: {
 
   // Inject needed capacity and pay fee
   const injectCapacityAndPayFeeResult = await injectCapacityAndPayFee({
-    txSkeleton,
     changeAddress: props.changeAddress,
     fromInfos: props.fromInfos,
-    fee: BI.from(0),
+    txSkeleton,
     config,
   });
   txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;

--- a/packages/core/src/api/composed/spore/transferSpore.ts
+++ b/packages/core/src/api/composed/spore/transferSpore.ts
@@ -64,7 +64,6 @@ export async function transferSpore(props: {
       txSkeleton,
       changeAddress: props.changeAddress,
       fromInfos: props.fromInfos!,
-      fee: BI.from(0),
       config,
     });
     txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;

--- a/packages/core/src/helpers/address.ts
+++ b/packages/core/src/helpers/address.ts
@@ -1,0 +1,28 @@
+import { Address } from '@ckb-lumos/base';
+import { helpers } from '@ckb-lumos/lumos';
+import { Config } from '@ckb-lumos/config-manager';
+import { FromInfo, parseFromInfo } from '@ckb-lumos/common-scripts';
+
+/**
+ * Check if the target address is valid.
+ */
+export function isAddressValid(address: Address, config?: Config) {
+  try {
+    helpers.parseAddress(address, { config });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Convert a FromInfo to a CKB address.
+ */
+export function fromInfoToAddress(fromInfo: FromInfo, config?: Config): Address {
+  if (typeof fromInfo === 'string' && isAddressValid(fromInfo)) {
+    return fromInfo as Address;
+  }
+
+  const parsed = parseFromInfo(fromInfo, { config });
+  return helpers.encodeToAddress(parsed.fromScript, { config });
+}

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -4,6 +4,7 @@ export * from './buffer';
 // Blockchain
 export * from './cell';
 export * from './script';
+export * from './address';
 export * from './typeId';
 export * from './capacity';
 export * from './transaction';

--- a/packages/core/src/helpers/script.ts
+++ b/packages/core/src/helpers/script.ts
@@ -1,6 +1,4 @@
-import { Address, Script, values } from '@ckb-lumos/base';
-import { Config } from '@ckb-lumos/config-manager';
-import { helpers } from '@ckb-lumos/lumos';
+import { Script, values } from '@ckb-lumos/base';
 import { ScriptId } from '../types';
 
 /**
@@ -15,18 +13,4 @@ export function isScriptValueEquals(a: Script, b: Script) {
  */
 export function isScriptIdEquals(a: ScriptId, b: ScriptId) {
   return a.codeHash === b.codeHash && a.hashType === b.hashType;
-}
-
-/**
- * Check if the target address is valid.
- */
-export function isAddressValid(address: Address, config: Config) {
-  try {
-    helpers.parseAddress(address, {
-      config,
-    });
-    return true;
-  } catch {
-    return false;
-  }
 }


### PR DESCRIPTION
### Changes
- Fix and optimize the logic of capacity collection
- Remove "fromInfos" prop from the "meltSpore" API

### Issues
- Resolves #34
- Resolves #33
