### PR TITLE
fix(sdk): live cell nullable

### DIFF
--- a/packages/core/src/__tests__/Cluster.test.ts
+++ b/packages/core/src/__tests__/Cluster.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 import { BI } from '@ckb-lumos/lumos';
 import { getSporeScript } from '../config';
 import { bytifyRawString, waitForMilliseconds } from '../helpers';
@@ -6,13 +6,26 @@ import { expectTypeId, expectCellDep, expectTypeCell, expectLockCell } from './h
 import { signAndSendTransaction, popRecord, OutPointRecord, IdRecord } from './helpers';
 import { retryQuery, getSporeOutput, getClusterOutput, expectCellLock } from './helpers';
 import { createCluster, createSpore, getClusterById, getClusterByOutPoint, transferCluster } from '../api';
-import { TEST_ENV, TEST_ACCOUNTS, SPORE_OUTPOINT_RECORDS, CLUSTER_OUTPOINT_RECORDS, TEST_VARIABLES } from './shared';
+import {
+  TEST_ENV,
+  TEST_ACCOUNTS,
+  SPORE_OUTPOINT_RECORDS,
+  CLUSTER_OUTPOINT_RECORDS,
+  TEST_VARIABLES,
+  cleanupRecords,
+} from './shared';
 
-describe('Cluster', function () {
+describe('Cluster', () => {
   const { rpc, config } = TEST_ENV;
   const { CHARLIE, ALICE } = TEST_ACCOUNTS;
 
   let existingClusterRecord: OutPointRecord | undefined;
+
+  afterAll(async () => {
+    await cleanupRecords({
+      name: 'Cluster',
+    });
+  }, 0);
 
   describe('Cluster basics', () => {
     it('Create a Cluster', async () => {

--- a/packages/core/src/__tests__/ClusterProxyAgent.test.ts
+++ b/packages/core/src/__tests__/ClusterProxyAgent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 import { BI } from '@ckb-lumos/lumos';
 import { getSporeScript } from '../config';
 import { bytifyRawString, minimalCellCapacityByLock } from '../helpers';
@@ -17,15 +17,22 @@ import {
   CLUSTER_OUTPOINT_RECORDS,
   CLUSTER_PROXY_OUTPOINT_RECORDS,
   CLUSTER_AGENT_OUTPOINT_RECORDS,
+  cleanupRecords,
 } from './shared';
 
-describe('ClusterProxy and ClusterAgent', function () {
+describe('ClusterProxy and ClusterAgent', () => {
   const { rpc, config } = TEST_ENV;
   const { CHARLIE, ALICE } = TEST_ACCOUNTS;
 
   let existingClusterRecord: OutPointRecord | undefined;
   let existingClusterProxyRecord: OutPointRecord | undefined;
   let existingClusterAgentRecord: OutPointRecord | undefined;
+
+  afterAll(async () => {
+    await cleanupRecords({
+      name: 'ClusterProxyAgent',
+    });
+  }, 0);
 
   describe('ClusterProxy basics', () => {
     it.skipIf(existingClusterRecord !== void 0 || CLUSTER_OUTPOINT_RECORDS.length > 0)(

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, afterAll } from 'vitest';
 import { BI } from '@ckb-lumos/lumos';
 import { getSporeScript } from '../config';
 import { unpackToRawMutantArgs } from '../codec';
@@ -6,11 +6,17 @@ import { bufferToRawString, bytifyRawString } from '../helpers';
 import { createSpore, transferSpore, meltSpore, getSporeByOutPoint, getMutantById } from '../api';
 import { expectCellDep, expectTypeId, expectTypeCell, expectCellLock } from './helpers';
 import { getSporeOutput, popRecord, retryQuery, signAndSendTransaction, OutPointRecord } from './helpers';
-import { TEST_ACCOUNTS, TEST_ENV, SPORE_OUTPOINT_RECORDS } from './shared';
+import { TEST_ACCOUNTS, TEST_ENV, SPORE_OUTPOINT_RECORDS, cleanupRecords } from './shared';
 
 describe('Spore', () => {
   const { rpc, config } = TEST_ENV;
   const { CHARLIE, ALICE } = TEST_ACCOUNTS;
+
+  afterAll(async () => {
+    await cleanupRecords({
+      name: 'Spore',
+    });
+  }, 0);
 
   describe('Spore basics', () => {
     let existingSporeRecord: OutPointRecord | undefined;

--- a/packages/core/src/__tests__/helpers/retry.ts
+++ b/packages/core/src/__tests__/helpers/retry.ts
@@ -3,13 +3,15 @@ import { retryWork } from '../../helpers';
 export async function retryQuery<T>(getter: () => T | Promise<T>): Promise<T> {
   const work = await retryWork({
     getter,
-    retry: 6,
+    retry: 8,
     interval: 10000,
   });
 
   if (!work.success) {
     if (work.errors.length > 0) {
-      throw work.errors.pop();
+      throw new Error(`RetryWork failed for ${work.retries} times`, {
+        cause: work.errors.pop(),
+      });
     } else {
       throw new Error(`RetryWork failed with no error for ${work.retries} times`);
     }

--- a/packages/core/src/__tests__/shared/record.ts
+++ b/packages/core/src/__tests__/shared/record.ts
@@ -1,5 +1,4 @@
 import { resolve } from 'path';
-import { afterAll } from 'vitest';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { retryWork } from '../../helpers';
 import { meltClusterAgent, meltClusterProxy, meltSpore } from '../../api';
@@ -12,7 +11,7 @@ export const CLUSTER_OUTPOINT_RECORDS: OutPointRecord[] = [];
 export const CLUSTER_PROXY_OUTPOINT_RECORDS: OutPointRecord[] = [];
 export const CLUSTER_AGENT_OUTPOINT_RECORDS: OutPointRecord[] = [];
 
-afterAll(async () => {
+export async function cleanupRecords(props: { name: string }) {
   const [sporeCleanupResults, clusterProxyCleanupResults, clusterAgentCleanupResults] = await Promise.all([
     cleanupSporeRecords(),
     cleanupClusterProxyRecords(),
@@ -31,12 +30,12 @@ afterAll(async () => {
   }
 
   const json = JSON.stringify(result, null, 2);
-  writeFileSync(resolve(path, `cleanup-${Date.now()}.json`), json);
-}, 0);
+  writeFileSync(resolve(path, `${props.name}-cleanup-${Date.now()}.json`), json);
+}
 
 const { config, rpc } = TEST_ENV;
 
-async function cleanupSporeRecords() {
+export async function cleanupSporeRecords() {
   const promises = SPORE_OUTPOINT_RECORDS.map((record) => {
     return retryWork({
       getter: async () => {
@@ -70,7 +69,7 @@ async function cleanupSporeRecords() {
   });
 }
 
-async function cleanupClusterProxyRecords() {
+export async function cleanupClusterProxyRecords() {
   const promises = CLUSTER_PROXY_OUTPOINT_RECORDS.map((record) => {
     return retryWork({
       getter: async () => {
@@ -104,7 +103,7 @@ async function cleanupClusterProxyRecords() {
   });
 }
 
-async function cleanupClusterAgentRecords() {
+export async function cleanupClusterAgentRecords() {
   const promises = CLUSTER_AGENT_OUTPOINT_RECORDS.map((record) => {
     return retryWork({
       getter: async () => {

--- a/packages/core/src/api/joints/cluster/getCluster.ts
+++ b/packages/core/src/api/joints/cluster/getCluster.ts
@@ -38,6 +38,9 @@ export async function getClusterByOutPoint(outPoint: OutPoint, config?: SporeCon
     outPoint,
     rpc,
   });
+  if (!cellWithStatus.cell) {
+    throw new Error('Cannot find cluster by OutPoint because target cell is unknown');
+  }
   if (cellWithStatus.status !== 'live') {
     throw new Error('Cannot find cluster by OutPoint because target cell is not lived');
   }

--- a/packages/core/src/api/joints/clusterAgent/getClusterAgent.ts
+++ b/packages/core/src/api/joints/clusterAgent/getClusterAgent.ts
@@ -13,6 +13,9 @@ export async function getClusterAgentByOutPoint(outPoint: OutPoint, config?: Spo
     outPoint,
     rpc,
   });
+  if (!cellWithStatus.cell) {
+    throw new Error('Cannot find ClusterAgent by OutPoint because target cell is unknown');
+  }
   if (cellWithStatus.status !== 'live') {
     throw new Error('Cannot find ClusterAgent by OutPoint because target cell is not lived');
   }

--- a/packages/core/src/api/joints/clusterProxy/getClusterProxy.ts
+++ b/packages/core/src/api/joints/clusterProxy/getClusterProxy.ts
@@ -35,6 +35,9 @@ export async function getClusterProxyByOutPoint(outPoint: OutPoint, config?: Spo
     outPoint,
     rpc,
   });
+  if (!cellWithStatus.cell) {
+    throw new Error('Cannot find ClusterProxy by OutPoint because target cell is unknown');
+  }
   if (cellWithStatus.status !== 'live') {
     throw new Error('Cannot find ClusterProxy by OutPoint because target cell is not lived');
   }

--- a/packages/core/src/api/joints/mutant/getMutant.ts
+++ b/packages/core/src/api/joints/mutant/getMutant.ts
@@ -35,6 +35,9 @@ export async function getMutantByOutPoint(outPoint: OutPoint, config?: SporeConf
     outPoint,
     rpc,
   });
+  if (!cellWithStatus.cell) {
+    throw new Error('Cannot find Mutant by OutPoint because target cell is unknown');
+  }
   if (cellWithStatus.status !== 'live') {
     throw new Error('Cannot find Mutant by OutPoint because target cell is not lived');
   }

--- a/packages/core/src/api/joints/spore/getSpore.ts
+++ b/packages/core/src/api/joints/spore/getSpore.ts
@@ -35,6 +35,9 @@ export async function getSporeByOutPoint(outPoint: OutPoint, config?: SporeConfi
 
   // Get cell from rpc
   const cellWithStatus = await getCellWithStatusByOutPoint({ outPoint, rpc });
+  if (!cellWithStatus.cell) {
+    throw new Error('Cannot find spore by OutPoint because target cell is unknown');
+  }
   if (cellWithStatus.status !== 'live') {
     throw new Error('Cannot find spore by OutPoint because target cell is not lived');
   }

--- a/packages/core/src/helpers/cell.ts
+++ b/packages/core/src/helpers/cell.ts
@@ -3,6 +3,7 @@ import { Config } from '@ckb-lumos/config-manager';
 import { common, FromInfo } from '@ckb-lumos/common-scripts';
 import { Hash, OutPoint, PackedSince, Script } from '@ckb-lumos/base';
 import { Cell, helpers, HexString, Indexer, RPC } from '@ckb-lumos/lumos';
+import { CKBComponents } from '@ckb-lumos/rpc/lib/types/api';
 import { ScriptId } from '../codec';
 import { isScriptValueEquals } from './script';
 
@@ -24,13 +25,18 @@ export async function getCellByType(props: { type: Script; indexer: Indexer }) {
 /**
  * A wrapper function, to get a Cell structure from RPC.getLiveCell() method.
  */
-export async function getCellWithStatusByOutPoint(props: { outPoint: OutPoint; rpc: RPC }) {
+export async function getCellWithStatusByOutPoint(props: { outPoint: OutPoint; rpc: RPC }): Promise<{
+  cell?: Cell;
+  status: CKBComponents.CellStatus;
+}> {
   const liveCell = await props.rpc.getLiveCell(props.outPoint, true);
-  const cell: Cell = {
-    cellOutput: liveCell.cell.output,
-    data: liveCell.cell.data.content,
-    outPoint: props.outPoint,
-  };
+  const cell: Cell | undefined = liveCell.cell
+    ? {
+        cellOutput: liveCell.cell.output,
+        data: liveCell.cell.data.content,
+        outPoint: props.outPoint,
+      }
+    : void 0;
 
   return {
     cell,

--- a/packages/core/src/helpers/cellDep.ts
+++ b/packages/core/src/helpers/cellDep.ts
@@ -20,7 +20,7 @@ export async function findCellDepIndexByTypeFromTransactionSkeleton(props: {
       rpc,
     });
 
-    if (target.cell.cellOutput.type && isScriptValueEquals(target.cell.cellOutput.type, props.type)) {
+    if (target.cell?.cellOutput.type && isScriptValueEquals(target.cell.cellOutput.type, props.type)) {
       return index;
     }
   }

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    watch: false,
+    fileParallelism: false,
     poolOptions: {
       threads: {
         singleThread: true,


### PR DESCRIPTION
## Changes
- Restricted the `afterAll` hook to only run in a Spore/Cluster/ClusterProxyAgent tests
- Fixed the return type of the `RPC.getLiveCell` API to optional/nullable
- Allowed more duration for each `retryQuery`

## Checklist
- [x] fixes #59 