### PR TITLE
chore(ci): rename spore-devenv

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout spore-devenv
         uses: actions/checkout@v4
         with:
-          repository: Dawn-githup/spore_devenv
+          repository: sporeprotocol/spore-devenv
           path: spore-devenv
 
       - name: Install Node.js


### PR DESCRIPTION
## Changes
- Rename devenv repo in the test ci from `Dawn-githup/spore_devenv` to `sporeprotocol/spore-devenv`