### PR TITLE
feat(sdk): cobuild basic support

### DIFF
--- a/.changeset/nine-bottles-report.md
+++ b/.changeset/nine-bottles-report.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Support finding SporeScripts by predefined tags

--- a/.changeset/twenty-planets-rest.md
+++ b/.changeset/twenty-planets-rest.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': minor
+---
+
+Support basic Cobuild feature with legacy locks

--- a/examples/acp/package.json
+++ b/examples/acp/package.json
@@ -9,11 +9,6 @@
   "dependencies": {
     "@spore-sdk/core": "workspace:^",
     "@spore-examples/shared": "workspace:^",
-    "@ckb-lumos/bi": "^0.21.1",
-    "@ckb-lumos/base": "^0.21.1",
-    "@ckb-lumos/lumos": "^0.21.1",
-    "@ckb-lumos/codec": "^0.21.1",
-    "@ckb-lumos/common-scripts": "^0.21.1",
     "ts-node": "^10.9.1"
   }
 }

--- a/examples/omnilock/package.json
+++ b/examples/omnilock/package.json
@@ -8,12 +8,6 @@
   "dependencies": {
     "@spore-sdk/core": "workspace:^",
     "@spore-examples/shared": "workspace:^",
-    "@ckb-lumos/bi": "^0.21.1",
-    "@ckb-lumos/base": "^0.21.1",
-    "@ckb-lumos/lumos": "^0.21.1",
-    "@ckb-lumos/codec": "^0.21.1",
-    "@ckb-lumos/common-scripts": "^0.21.1",
-    "@ckb-lumos/config-manager": "^0.21.1",
     "ts-node": "^10.9.1",
     "lodash": "^4.17.21"
   }

--- a/examples/secp256k1/package.json
+++ b/examples/secp256k1/package.json
@@ -9,10 +9,6 @@
   "dependencies": {
     "@spore-sdk/core": "workspace:^",
     "@spore-examples/shared": "workspace:^",
-    "@ckb-lumos/bi": "^0.21.1",
-    "@ckb-lumos/base": "^0.21.1",
-    "@ckb-lumos/lumos": "^0.21.1",
-    "@ckb-lumos/common-scripts": "^0.21.1",
     "ts-node": "^10.9.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,13 +17,13 @@
     "lib"
   ],
   "dependencies": {
-    "@ckb-lumos/base": "^0.21.1",
-    "@ckb-lumos/bi": "^0.21.1",
-    "@ckb-lumos/codec": "^0.21.1",
-    "@ckb-lumos/common-scripts": "^0.21.1",
-    "@ckb-lumos/config-manager": "^0.21.1",
-    "@ckb-lumos/lumos": "^0.21.1",
-    "@ckb-lumos/rpc": "^0.21.1",
+    "@ckb-lumos/bi": "^0.22.0-next.2",
+    "@ckb-lumos/rpc": "^0.22.0-next.2",
+    "@ckb-lumos/base": "^0.22.0-next.2",
+    "@ckb-lumos/lumos": "^0.22.0-next.2",
+    "@ckb-lumos/codec": "^0.22.0-next.2",
+    "@ckb-lumos/config-manager": "^0.22.0-next.2",
+    "@ckb-lumos/common-scripts": "^0.22.0-next.2",
     "@exact-realty/multipart-parser": "^1.0.9",
     "lodash": "^4.17.21"
   },

--- a/packages/core/src/__tests__/Cluster.test.ts
+++ b/packages/core/src/__tests__/Cluster.test.ts
@@ -131,7 +131,7 @@ describe('Cluster', () => {
 
       expectLockCell(txSkeleton, 'both', clusterCell.cellOutput.lock);
 
-      const clusterScript = getSporeScript(config, 'Cluster', clusterCell.cellOutput.type);
+      const clusterScript = getSporeScript(config, 'Cluster', clusterCell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterScript.cellDep);
       expectCellDep(txSkeleton, {
         outPoint: clusterRecord.outPoint,
@@ -191,7 +191,7 @@ describe('Cluster', () => {
       expectTypeCell(txSkeleton, 'both', cluster.cell.cellOutput.type!);
       expect(cluster.id).toEqual(clusterId);
 
-      const clusterScript = getSporeScript(config, 'Cluster', clusterCell.cellOutput.type);
+      const clusterScript = getSporeScript(config, 'Cluster', clusterCell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterScript.cellDep);
       expectCellDep(txSkeleton, {
         outPoint: clusterRecord.outPoint,
@@ -270,7 +270,7 @@ describe('Cluster', () => {
       expectTypeCell(txSkeleton, 'both', cluster.cell.cellOutput.type!);
       expect(cluster.id).toEqual(clusterRecord.id);
 
-      const clusterScript = getSporeScript(config, 'Cluster', cluster.cell.cellOutput.type);
+      const clusterScript = getSporeScript(config, 'Cluster', cluster.cell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterScript.cellDep);
       expectCellDep(txSkeleton, {
         outPoint: clusterCell.outPoint!,

--- a/packages/core/src/__tests__/Cluster.test.ts
+++ b/packages/core/src/__tests__/Cluster.test.ts
@@ -230,6 +230,29 @@ describe('Cluster', () => {
       id: '0x8b9f893397310a3bbd925cd1c9ab606555675bb2d03f3c5cb934f2ba4ef97e93',
       account: CHARLIE,
     };
+    it('Create a Spore with Cluster (via lock proxy)', async () => {
+      expect(clusterV1IdRecord).toBeDefined();
+      const clusterRecord = clusterV1IdRecord;
+      const clusterCell = await retryQuery(async () => {
+        const cell = await getClusterById(clusterRecord.id, config);
+        return await getClusterByOutPoint(cell.outPoint!, config);
+      });
+
+      expectCellLock(clusterCell, [CHARLIE.lock, ALICE.lock]);
+
+      await expect(() =>
+        createSpore({
+          data: {
+            clusterId: clusterRecord.id,
+            contentType: 'text/plain',
+            content: bytifyRawString('content'),
+          },
+          toLock: clusterRecord.account.lock,
+          fromInfos: [clusterRecord.account.address],
+          config,
+        }),
+      ).rejects.toThrowError('Cannot reference Cluster because target Cluster does not supported lockProxy');
+    }, 0);
     it('Create a Spore with Cluster (via cell reference)', async () => {
       expect(clusterV1IdRecord).toBeDefined();
       const clusterRecord = clusterV1IdRecord;

--- a/packages/core/src/__tests__/ClusterProxyAgent.test.ts
+++ b/packages/core/src/__tests__/ClusterProxyAgent.test.ts
@@ -155,7 +155,7 @@ describe('ClusterProxy and ClusterAgent', () => {
 
       expectTypeCell(txSkeleton, 'both', clusterCell.cellOutput.type!);
 
-      const clusterScript = getSporeScript(config, 'Cluster', clusterCell.cellOutput.type);
+      const clusterScript = getSporeScript(config, 'Cluster', clusterCell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterScript.cellDep);
       expectCellDep(txSkeleton, {
         outPoint: clusterRecord.outPoint,
@@ -240,7 +240,7 @@ describe('ClusterProxy and ClusterAgent', () => {
 
       expectTypeCell(txSkeleton, 'input', clusterProxyCell.cellOutput.type!);
 
-      const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyType);
+      const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyType!);
       expectCellDep(txSkeleton, clusterProxyScript.cellDep);
 
       const hash = await signAndSendTransaction({
@@ -295,7 +295,7 @@ describe('ClusterProxy and ClusterAgent', () => {
       const expectedPayment = lockRequiredCapacity.gt(minimalPayment) ? lockRequiredCapacity : minimalPayment;
       expect(BI.from(paymentCell!.cellOutput.capacity).gte(expectedPayment)).toEqual(true);
 
-      const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyCell.cellOutput.type);
+      const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyCell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterProxyScript.cellDep);
       expectCellDep(txSkeleton, {
         outPoint: clusterProxyRecord.outPoint,
@@ -350,7 +350,7 @@ describe('ClusterProxy and ClusterAgent', () => {
 
       expectTypeCell(txSkeleton, 'both', clusterProxyCell.cellOutput.type!);
 
-      const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyCell.cellOutput.type);
+      const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyCell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterProxyScript.cellDep);
       expectCellDep(txSkeleton, {
         outPoint: clusterProxyRecord.outPoint,
@@ -474,7 +474,7 @@ describe('ClusterProxy and ClusterAgent', () => {
       expect(reference.referenceType).toEqual('lockProxy');
       expectLockCell(txSkeleton, 'both', clusterAgentCell.cellOutput.lock);
 
-      const clusterScript = getSporeScript(config, 'ClusterAgent', clusterAgentCell.cellOutput.type);
+      const clusterScript = getSporeScript(config, 'ClusterAgent', clusterAgentCell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterScript.cellDep);
       expectCellDep(txSkeleton, {
         outPoint: clusterAgentRecord.outPoint,
@@ -608,7 +608,7 @@ describe('ClusterProxy and ClusterAgent', () => {
 
       expectTypeCell(txSkeleton, 'both', clusterCell.cellOutput.type!);
 
-      const clusterScript = getSporeScript(config, 'Cluster', clusterCell.cellOutput.type);
+      const clusterScript = getSporeScript(config, 'Cluster', clusterCell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterScript.cellDep);
       expectCellDep(txSkeleton, {
         outPoint: clusterCell.outPoint!,

--- a/packages/core/src/__tests__/Codec.test.ts
+++ b/packages/core/src/__tests__/Codec.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { bytes } from '@ckb-lumos/codec';
 import { BI, HexString } from '@ckb-lumos/lumos';
 import { bytifyRawString } from '../helpers';
-import { packRawSporeData, unpackToRawSporeData, RawSporeData } from '../codec';
+import { packRawSporeData, unpackToRawSporeData, RawSporeData, RawString } from '../codec';
 import { packRawClusterData, unpackToRawClusterData, RawClusterData } from '../codec';
 import { packRawClusterProxyArgs, unpackToRawClusterProxyArgs, RawClusterProxyArgs } from '../codec';
 import { packRawClusterAgentDataToHash, RawClusterAgentData } from '../codec';
@@ -13,6 +13,14 @@ interface PackableTest<T> {
 }
 
 describe('Codec', function () {
+  /**
+   * RawString
+   */
+  it('Encode via RawString codec', () => {
+    expect(RawString.pack('content')).toEqual(bytes.bytify('0x07000000636f6e74656e74'));
+    expect(RawString.unpack('0x07000000636f6e74656e74')).toEqual('content');
+  });
+
   /**
    * SporeData
    */

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -115,7 +115,7 @@ describe('Spore', () => {
       expect(changeCell).toBeDefined();
       expect(changeCell!.cellOutput.lock).toEqual(CHARLIE.lock);
 
-      const sporeScript = getSporeScript(config, 'Spore', sporeCell.cellOutput.type);
+      const sporeScript = getSporeScript(config, 'Spore', sporeCell.cellOutput.type!);
       expectCellDep(txSkeleton, sporeScript.cellDep);
 
       const hash = await signAndSendTransaction({

--- a/packages/core/src/__tests__/SporeConfig.test.ts
+++ b/packages/core/src/__tests__/SporeConfig.test.ts
@@ -1,20 +1,25 @@
 import cloneDeep from 'lodash/cloneDeep';
 import { describe, expect, it } from 'vitest';
 import { TEST_ENV } from './shared';
-import { forkSporeConfig, getSporeConfigHash, isSporeScriptCategorySupported } from '../config';
+import {
+  SporeConfig,
+  getSporeScript,
+  forkSporeConfig,
+  getSporeConfigHash,
+  isSporeScriptCategorySupported,
+} from '../config';
 
 describe('SporeConfig', function () {
+  const { config } = TEST_ENV;
   it('Hash a SporeConfig', () => {
     const config = cloneDeep(TEST_ENV.config);
     const hash1 = getSporeConfigHash(config);
 
     config.maxTransactionSize = Math.random() * 1000;
     const hash2 = getSporeConfigHash(config);
-
-    expect(hash1).not.eq(hash2, 'Hash should be different after altering the config');
+    expect(hash1).not.toEqual(hash2);
   });
-  it('Fork a SporeConfig', function () {
-    const { config } = TEST_ENV;
+  it('Fork a SporeConfig', () => {
     const newConfig = forkSporeConfig(config, {
       scripts: {
         Some: {
@@ -43,5 +48,203 @@ describe('SporeConfig', function () {
 
     const categoryExistsInNewConfig = isSporeScriptCategorySupported(newConfig, 'Some');
     expect(categoryExistsInNewConfig).eq(true, 'New SporeConfig should have "Some" script');
+  });
+  it('Get SporeScript by ScriptId', () => {
+    const newConfig = forkSporeConfig(config, {
+      scripts: {
+        Some: {
+          versions: [
+            {
+              tags: ['v2'],
+              script: {
+                codeHash: '0x00',
+                hashType: 'type',
+              },
+              cellDep: {
+                outPoint: {
+                  txHash: '0x00',
+                  index: '0x0',
+                },
+                depType: 'code',
+              },
+            },
+            {
+              tags: ['v1'],
+              script: {
+                codeHash: '0x01',
+                hashType: 'type',
+              },
+              cellDep: {
+                outPoint: {
+                  txHash: '0x01',
+                  index: '0x0',
+                },
+                depType: 'code',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const script = getSporeScript(newConfig, 'Some', {
+      codeHash: '0x01',
+      hashType: 'type',
+    });
+    expect(script).toHaveProperty('tags', ['v1']);
+    expect(script.script).toHaveProperty('codeHash');
+    expect(script.script).toHaveProperty('codeHash', '0x01');
+  });
+  it('Match tags', () => {
+    const cases = [
+      {
+        tags: ['v2'],
+        fullTags: ['v2'],
+        result: true,
+      },
+      {
+        tags: ['v2'],
+        fullTags: ['v1'],
+        result: false,
+      },
+      {
+        tags: ['v2'],
+        fullTags: ['v1', 'v2'],
+        result: true,
+      },
+      {
+        tags: ['v2'],
+        fullTags: ['v1', 'v2', 'v3'],
+        result: true,
+      },
+      {
+        tags: ['v2'],
+        fullTags: ['v1', 'v3'],
+        result: false,
+      },
+      {
+        tags: ['v2', 'preview'],
+        fullTags: ['v1', 'v2'],
+        result: false,
+      },
+      {
+        tags: ['v2', 'preview'],
+        fullTags: ['v1', 'v2', 'v3'],
+        result: false,
+      },
+      {
+        tags: ['v2', 'preview'],
+        fullTags: ['v1', 'v2', 'preview'],
+        result: true,
+      },
+      {
+        tags: ['v2', 'preview'],
+        fullTags: ['v1', 'preview', 'v2'],
+        result: true,
+      },
+      {
+        tags: ['v2', 'preview'],
+        fullTags: ['v1', 'v2', 'preview', 'v3'],
+        result: true,
+      },
+      {
+        tags: ['v2', 'preview'],
+        fullTags: ['v1', 'v2', 'preview', 'v3', 'v4'],
+        result: true,
+      },
+    ];
+
+    function generateRegex(tags: string[]) {
+      const patterns = tags.sort().join(',.*');
+      return new RegExp(`${patterns}.*`, 'g');
+    }
+    function match(tags: string[], patterns: string[]) {
+      const regex = generateRegex(patterns);
+      return regex.test(tags.sort().join(','));
+    }
+    for (let i = 0; i < cases.length; i++) {
+      const { tags, fullTags, result } = cases[i];
+      expect(match(fullTags, tags)).eq(result, `Match case #${i}`);
+    }
+  });
+  it('Get SporeScript by tags', () => {
+    const newConfig: SporeConfig = {
+      defaultTags: ['latest'],
+      lumos: config.lumos,
+      ckbNodeUrl: '',
+      ckbIndexerUrl: '',
+      maxTransactionSize: 1,
+      scripts: {
+        Spore: {
+          versions: [
+            {
+              tags: ['v2', 'preview'],
+              script: {
+                codeHash: '0x00',
+                hashType: 'data1',
+              },
+              cellDep: {
+                outPoint: {
+                  txHash: '0x01',
+                  index: '0x0',
+                },
+                depType: 'code',
+              },
+            },
+            {
+              tags: ['v1', 'latest'],
+              script: {
+                codeHash: '0x02',
+                hashType: 'data1',
+              },
+              cellDep: {
+                outPoint: {
+                  txHash: '0x03',
+                  index: '0x0',
+                },
+                depType: 'code',
+              },
+            },
+          ],
+        },
+        Cluster: {
+          versions: [
+            {
+              tags: ['v2', 'preview'],
+              script: {
+                codeHash: '0x04',
+                hashType: 'data1',
+              },
+              cellDep: {
+                outPoint: {
+                  txHash: '0x05',
+                  index: '0x0',
+                },
+                depType: 'code',
+              },
+            },
+            {
+              tags: ['v1', 'latest'],
+              script: {
+                codeHash: '0x598d793defef36e2eeba54a9b45130e4ca92822e1d193671f490950c3b856080',
+                hashType: 'data1',
+              },
+              cellDep: {
+                outPoint: {
+                  txHash: '0x49551a20dfe39231e7db49431d26c9c08ceec96a29024eef3acc936deeb2ca76',
+                  index: '0x0',
+                },
+                depType: 'code',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const script = getSporeScript(newConfig, 'Spore', ['v2']);
+    expect(script).toBeDefined();
+    expect(script!.tags).toBeDefined();
+    expect(script!.tags.includes('v2')).toEqual(true);
   });
 });

--- a/packages/core/src/__tests__/helpers/config.ts
+++ b/packages/core/src/__tests__/helpers/config.ts
@@ -38,6 +38,10 @@ export function generateDevnetSporeConfig(config: Record<any, any>): SporeConfig
               },
               depType: config.SCRIPTS.SPORE.DEP_TYPE,
             },
+            behaviors: {
+              lockProxy: true,
+              cobuild: true,
+            },
           },
         ],
       },
@@ -55,6 +59,10 @@ export function generateDevnetSporeConfig(config: Record<any, any>): SporeConfig
                 index: config.SCRIPTS.CLUSTER.INDEX,
               },
               depType: config.SCRIPTS.CLUSTER.DEP_TYPE,
+            },
+            behaviors: {
+              lockProxy: true,
+              cobuild: true,
             },
           },
         ],
@@ -74,6 +82,10 @@ export function generateDevnetSporeConfig(config: Record<any, any>): SporeConfig
               },
               depType: config.SCRIPTS.CLUSTER_PROXY.DEP_TYPE,
             },
+            behaviors: {
+              lockProxy: true,
+              cobuild: true,
+            },
           },
         ],
       },
@@ -91,6 +103,10 @@ export function generateDevnetSporeConfig(config: Record<any, any>): SporeConfig
                 index: config.SCRIPTS.CLUSTER_AGENT.INDEX,
               },
               depType: config.SCRIPTS.CLUSTER_AGENT.DEP_TYPE,
+            },
+            behaviors: {
+              lockProxy: true,
+              cobuild: true,
             },
           },
         ],

--- a/packages/core/src/api/composed/clusterProxy/transferClusterProxy.ts
+++ b/packages/core/src/api/composed/clusterProxy/transferClusterProxy.ts
@@ -2,8 +2,9 @@ import { BIish } from '@ckb-lumos/bi';
 import { FromInfo } from '@ckb-lumos/common-scripts';
 import { Address, OutPoint, PackedSince, Script } from '@ckb-lumos/base';
 import { BI, Cell, helpers, HexString, Indexer } from '@ckb-lumos/lumos';
-import { getSporeConfig, SporeConfig } from '../../../config';
 import { injectCapacityAndPayFee, payFeeByOutput } from '../../../helpers';
+import { getSporeConfig, getSporeScript, SporeConfig } from '../../../config';
+import { generateTransferClusterProxyAction, injectCommonCobuildProof } from '../../../cobuild';
 import { getClusterProxyByOutPoint } from '../../joints/clusterProxy/getClusterProxy';
 import { injectLiveClusterProxyCell } from '../../joints/clusterProxy/injectLiveClusterProxyCell';
 
@@ -45,6 +46,7 @@ export async function transferClusterProxy(props: {
 
   // Get target ClusterProxy cell
   const clusterProxyCell = await getClusterProxyByOutPoint(props.outPoint, config);
+  const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyCell.cellOutput.type!);
 
   // Inject live ClusterProxy cell to inputs/outputs of the Transaction
   const injectLiveClusterProxyCellResult = await injectLiveClusterProxyCell({
@@ -67,16 +69,44 @@ export async function transferClusterProxy(props: {
   });
   txSkeleton = injectLiveClusterProxyCellResult.txSkeleton;
 
+  // Generate TransferClusterProxy actions
+  const actionResult = generateTransferClusterProxyAction({
+    txSkeleton,
+    inputIndex: injectLiveClusterProxyCellResult.inputIndex,
+    outputIndex: injectLiveClusterProxyCellResult.outputIndex,
+  });
+
   if (!useCapacityMarginAsFee) {
     // Inject needed capacity from fromInfos and pay fee
     const injectCapacityAndPayFeeResult = await injectCapacityAndPayFee({
       txSkeleton,
       fromInfos: props.fromInfos!,
       changeAddress: props.changeAddress,
+      updateTxSkeletonAfterCollection(_txSkeleton) {
+        // Inject CobuildProof
+        if (clusterProxyScript.behaviors?.cobuild) {
+          const injectCobuildProofResult = injectCommonCobuildProof({
+            txSkeleton: _txSkeleton,
+            actions: actionResult.actions,
+          });
+          _txSkeleton = injectCobuildProofResult.txSkeleton;
+        }
+
+        return _txSkeleton;
+      },
       config,
     });
     txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;
   } else {
+    // Inject CobuildProof
+    if (clusterProxyScript.behaviors?.cobuild) {
+      const injectCobuildProofResult = injectCommonCobuildProof({
+        txSkeleton,
+        actions: actionResult.actions,
+      });
+      txSkeleton = injectCobuildProofResult.txSkeleton;
+    }
+
     // Pay fee by the spore cell's capacity margin
     txSkeleton = await payFeeByOutput({
       outputIndex: injectLiveClusterProxyCellResult.outputIndex,

--- a/packages/core/src/api/joints/cluster/getCluster.ts
+++ b/packages/core/src/api/joints/cluster/getCluster.ts
@@ -16,13 +16,13 @@ export async function getClusterByType(type: Script, config?: SporeConfig): Prom
   // Get cell by type
   const cell = await getCellByType({ type, indexer });
   if (cell === void 0) {
-    throw new Error('Cannot find cluster by Type because target cell does not exist');
+    throw new Error('Cannot find Cluster by Type because target cell does not exist');
   }
 
   // Check target cell's type script
   const cellType = cell.cellOutput.type;
   if (!cellType || !isSporeScriptSupported(config, cellType, 'Cluster')) {
-    throw new Error('Cannot find cluster by Type because target cell is not Cluster');
+    throw new Error('Cannot find Cluster by Type because target cell is not Cluster');
   }
 
   return cell;
@@ -39,16 +39,16 @@ export async function getClusterByOutPoint(outPoint: OutPoint, config?: SporeCon
     rpc,
   });
   if (!cellWithStatus.cell) {
-    throw new Error('Cannot find cluster by OutPoint because target cell is unknown');
+    throw new Error('Cannot find Cluster by OutPoint because target cell is unknown');
   }
   if (cellWithStatus.status !== 'live') {
-    throw new Error('Cannot find cluster by OutPoint because target cell is not lived');
+    throw new Error('Cannot find Cluster by OutPoint because target cell is not lived');
   }
 
   // Check target cell's type script
   const cellType = cellWithStatus.cell.cellOutput.type;
   if (!cellType || !isSporeScriptSupported(config, cellType, 'Cluster')) {
-    throw new Error('Cannot find cluster by OutPoint because target cell is not Cluster');
+    throw new Error('Cannot find Cluster by OutPoint because target cell is not Cluster');
   }
 
   return cellWithStatus.cell;
@@ -83,5 +83,5 @@ export async function getClusterById(id: HexString, config?: SporeConfig): Promi
     }
   }
 
-  throw new Error(`Cannot find cluster by ClusterId because target cell does not exist or it's not Cluster`);
+  throw new Error(`Cannot find Cluster by Id because target cell does not exist or it's not Cluster`);
 }

--- a/packages/core/src/api/joints/cluster/injectLiveClusterCell.ts
+++ b/packages/core/src/api/joints/cluster/injectLiveClusterCell.ts
@@ -27,11 +27,11 @@ export async function injectLiveClusterCell(props: {
   // Get TransactionSkeleton
   let txSkeleton = props.txSkeleton;
 
-  // Check target cell type
+  // Check target cell's type
   const clusterCellType = clusterCell.cellOutput.type;
-  const clusterScript = getSporeScript(config, 'Cluster', clusterCellType);
+  const clusterScript = getSporeScript(config, 'Cluster', clusterCellType!);
   if (!clusterCellType || !clusterScript) {
-    throw new Error('Cannot inject cluster because target cell is not Cluster');
+    throw new Error('Cannot inject Cluster because target cell is not Cluster');
   }
 
   // Add cluster cell to Transaction.inputs

--- a/packages/core/src/api/joints/clusterAgent/injectLiveClusterAgentCell.ts
+++ b/packages/core/src/api/joints/clusterAgent/injectLiveClusterAgentCell.ts
@@ -29,7 +29,7 @@ export async function injectLiveClusterAgentCell(props: {
 
   // Check the target cell's type
   const cellType = clusterAgentCell.cellOutput.type;
-  const clusterAgentScript = getSporeScript(config, 'ClusterAgent', cellType);
+  const clusterAgentScript = getSporeScript(config, 'ClusterAgent', cellType!);
   if (!cellType || !clusterAgentScript) {
     throw new Error('Cannot inject ClusterAgent because target cell is not ClusterAgent');
   }

--- a/packages/core/src/api/joints/clusterAgent/injectLiveClusterAgentReference.ts
+++ b/packages/core/src/api/joints/clusterAgent/injectLiveClusterAgentReference.ts
@@ -59,9 +59,9 @@ export async function injectLiveClusterAgentReference(props: {
     },
     referenceLockProxy(tx) {
       const cellType = clusterAgentCell.cellOutput.type;
-      const clusterAgentScript = getSporeScript(config, 'ClusterAgent', cellType);
-      if (!cellType || !clusterAgentScript) {
-        throw new Error('Cannot inject ClusterAgent because target cell is not ClusterAgent');
+      const clusterAgentScript = getSporeScript(config, 'ClusterAgent', cellType!);
+      if (!clusterAgentScript.behaviors?.lockProxy) {
+        throw new Error('Cannot reference ClusterAgent because target cell does not supported lockProxy');
       }
 
       // Add ClusterAgent required cellDeps

--- a/packages/core/src/api/joints/clusterProxy/injectLiveClusterProxyCell.ts
+++ b/packages/core/src/api/joints/clusterProxy/injectLiveClusterProxyCell.ts
@@ -32,7 +32,7 @@ export async function injectLiveClusterProxyCell(props: {
 
   // Check target cell's type
   const cellType = clusterProxyCell.cellOutput.type;
-  const clusterProxyScript = getSporeScript(config, 'ClusterProxy', cellType);
+  const clusterProxyScript = getSporeScript(config, 'ClusterProxy', cellType!);
   if (!cellType || !clusterProxyScript) {
     throw new Error('Cannot inject ClusterProxy because target cell is not ClusterProxy');
   }

--- a/packages/core/src/api/joints/clusterProxy/injectLiveClusterProxyReference.ts
+++ b/packages/core/src/api/joints/clusterProxy/injectLiveClusterProxyReference.ts
@@ -41,7 +41,7 @@ export async function injectLiveClusterProxyReference(props: {
 
   // Get ClusterProxy's type script
   const clusterProxyType = clusterProxyCell.cellOutput.type;
-  const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyType);
+  const clusterProxyScript = getSporeScript(config, 'ClusterProxy', clusterProxyType!);
   if (!clusterProxyType || !clusterProxyScript) {
     throw new Error('Cannot inject ClusterProxy because target cell is not ClusterProxy');
   }

--- a/packages/core/src/api/joints/mutant/injectLiveMutantCell.ts
+++ b/packages/core/src/api/joints/mutant/injectLiveMutantCell.ts
@@ -32,7 +32,7 @@ export async function injectLiveMutantCell(props: {
 
   // Check target cell's type
   const mutantCellType = mutantCell.cellOutput.type;
-  const mutantScript = getSporeScript(config, 'Mutant', mutantCellType);
+  const mutantScript = getSporeScript(config, 'Mutant', mutantCellType!);
   if (!mutantCellType || !mutantScript) {
     throw new Error('Cannot inject Mutant because target cell is not Mutant');
   }

--- a/packages/core/src/api/joints/spore/injectLiveSporeCell.ts
+++ b/packages/core/src/api/joints/spore/injectLiveSporeCell.ts
@@ -31,7 +31,7 @@ export async function injectLiveSporeCell(props: {
 
   // Check target cell's type script id
   const sporeType = sporeCell.cellOutput.type;
-  const sporeScript = getSporeScript(config, 'Spore', sporeType);
+  const sporeScript = getSporeScript(config, 'Spore', sporeType!);
   if (!sporeType || !sporeScript) {
     throw new Error('Cannot inject live spore because target cell type is not Spore');
   }

--- a/packages/core/src/api/joints/spore/injectNewSporeOutput.ts
+++ b/packages/core/src/api/joints/spore/injectNewSporeOutput.ts
@@ -137,7 +137,7 @@ export async function injectNewSporeOutput(props: {
 
     // Even if not referencing Cluster, still make sure Cluster related cellDeps are added
     const clusterType = clusterCell!.cellOutput.type;
-    const clusterScript = getSporeScript(config, 'Cluster', clusterType);
+    const clusterScript = getSporeScript(config, 'Cluster', clusterType!);
     if (!clusterType || !clusterScript) {
       throw new Error('Cannot reference Cluster because target cell is not Cluster');
     }

--- a/packages/core/src/cobuild/action/cluster/createCluster.ts
+++ b/packages/core/src/cobuild/action/cluster/createCluster.ts
@@ -1,0 +1,64 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+
+export function generateCreateClusterAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const clusterOutput = txSkeleton.get('outputs').get(props.outputIndex);
+
+  const clusterType = clusterOutput!.cellOutput.type!;
+  const clusterTypeHash = utils.computeScriptHash(clusterType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: clusterTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'CreateCluster',
+    value: {
+      clusterId: clusterType.args,
+      dataHash: utils.ckbHash(clusterOutput!.data),
+      to: {
+        type: 'Script',
+        value: clusterOutput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: clusterTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateCreateClusterBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateCreateClusterAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/cluster/referenceCluster.ts
+++ b/packages/core/src/cobuild/action/cluster/referenceCluster.ts
@@ -1,0 +1,32 @@
+import { helpers } from '@ckb-lumos/lumos';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { generateTransferClusterAction } from './transferCluster';
+import { UnpackResult } from '@ckb-lumos/codec';
+
+export function generateReferenceClusterAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  referenceType: 'cell' | 'lockProxy';
+  cluster?: {
+    inputIndex: number;
+    outputIndex: number;
+  };
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  if (props.referenceType === 'lockProxy') {
+    return {
+      actions: [],
+      scriptInfos: [],
+    };
+  }
+  if (!props.cluster) {
+    throw new Error('Cannot generate TransferCluster Action without cluster info');
+  }
+
+  return generateTransferClusterAction({
+    txSkeleton: props.txSkeleton,
+    inputIndex: props.cluster.inputIndex,
+    outputIndex: props.cluster.outputIndex,
+  });
+}

--- a/packages/core/src/cobuild/action/cluster/transferCluster.ts
+++ b/packages/core/src/cobuild/action/cluster/transferCluster.ts
@@ -1,0 +1,71 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+
+export function generateTransferClusterAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const clusterInput = txSkeleton.get('inputs').get(props.inputIndex);
+  const clusterOutput = txSkeleton.get('outputs').get(props.outputIndex);
+
+  const clusterType = clusterOutput!.cellOutput.type!;
+  const clusterTypeHash = utils.computeScriptHash(clusterType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: clusterTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'TransferCluster',
+    value: {
+      clusterId: clusterType.args,
+      from: {
+        type: 'Script',
+        value: clusterInput!.cellOutput.lock,
+      },
+      to: {
+        type: 'Script',
+        value: clusterOutput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: clusterTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateTransferClusterBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+  useCapacityMarginAsFee: boolean;
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateTransferClusterAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: props.useCapacityMarginAsFee ? props.outputIndex : txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/clusterAgent/createClusterAgent.ts
+++ b/packages/core/src/cobuild/action/clusterAgent/createClusterAgent.ts
@@ -1,0 +1,79 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { injectNewClusterAgentOutput } from '../../../api';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+import { generateReferenceClusterProxyAction } from '../clusterProxy/referenceClusterProxy';
+import { Hash } from '@ckb-lumos/base';
+
+export function generateCreateClusterAgentAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+  clusterProxyId: Hash;
+  reference: Awaited<ReturnType<typeof injectNewClusterAgentOutput>>['reference'];
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const clusterOutput = txSkeleton.get('outputs').get(props.outputIndex);
+
+  const clusterAgentType = clusterOutput!.cellOutput.type!;
+  const clusterAgentTypeHash = utils.computeScriptHash(clusterAgentType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: clusterAgentTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'CreateClusterAgent',
+    value: {
+      clusterId: clusterAgentType.args,
+      clusterProxyId: props.clusterProxyId,
+      to: {
+        type: 'Script',
+        value: clusterOutput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: clusterAgentTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  const clusterAction = generateReferenceClusterProxyAction({
+    txSkeleton,
+    referenceType: props.reference.referenceType,
+    clusterProxy: props.reference.clusterProxy,
+  });
+  actions.push(...clusterAction.actions);
+  scriptInfos.push(...clusterAction.scriptInfos);
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateCreateClusterAgentBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+  clusterProxyId: Hash;
+  reference: Awaited<ReturnType<typeof injectNewClusterAgentOutput>>['reference'];
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateCreateClusterAgentAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/clusterAgent/meltClusterAgent.ts
+++ b/packages/core/src/cobuild/action/clusterAgent/meltClusterAgent.ts
@@ -28,7 +28,7 @@ export function generateMeltClusterAgentAction(props: {
   const actionData = SporeAction.pack({
     type: 'MeltClusterAgent',
     value: {
-      clusterId: clusterAgentInput!.data,
+      clusterId: clusterAgentInput!.cellOutput.type!.args,
       from: {
         type: 'Script',
         value: clusterAgentInput!.cellOutput.lock,

--- a/packages/core/src/cobuild/action/clusterAgent/meltClusterAgent.ts
+++ b/packages/core/src/cobuild/action/clusterAgent/meltClusterAgent.ts
@@ -1,0 +1,63 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+
+export function generateMeltClusterAgentAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const clusterAgentInput = txSkeleton.get('inputs').get(props.inputIndex);
+
+  const clusterAgentType = clusterAgentInput!.cellOutput.type!;
+  const clusterAgentTypeHash = utils.computeScriptHash(clusterAgentType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: clusterAgentTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'MeltClusterAgent',
+    value: {
+      clusterId: clusterAgentInput!.data,
+      from: {
+        type: 'Script',
+        value: clusterAgentInput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: clusterAgentTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateMeltClusterAgentBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateMeltClusterAgentAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/clusterAgent/referenceClusterAgent.ts
+++ b/packages/core/src/cobuild/action/clusterAgent/referenceClusterAgent.ts
@@ -1,0 +1,32 @@
+import { helpers } from '@ckb-lumos/lumos';
+import { UnpackResult } from '@ckb-lumos/codec';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { generateTransferClusterAgentAction } from './transferClusterAgent';
+
+export function generateReferenceClusterAgentAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  referenceType: 'cell' | 'lockProxy';
+  clusterAgent?: {
+    inputIndex: number;
+    outputIndex: number;
+  };
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  if (props.referenceType === 'lockProxy') {
+    return {
+      actions: [],
+      scriptInfos: [],
+    };
+  }
+  if (!props.clusterAgent) {
+    throw new Error('Cannot generate TransferClusterAgent Action without clusterAgent info');
+  }
+
+  return generateTransferClusterAgentAction({
+    txSkeleton: props.txSkeleton,
+    inputIndex: props.clusterAgent.inputIndex,
+    outputIndex: props.clusterAgent.outputIndex,
+  });
+}

--- a/packages/core/src/cobuild/action/clusterAgent/transferClusterAgent.ts
+++ b/packages/core/src/cobuild/action/clusterAgent/transferClusterAgent.ts
@@ -1,0 +1,71 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+
+export function generateTransferClusterAgentAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const clusterAgentInput = txSkeleton.get('inputs').get(props.inputIndex);
+  const clusterAgentOutput = txSkeleton.get('outputs').get(props.outputIndex);
+
+  const clusterAgentType = clusterAgentOutput!.cellOutput.type!;
+  const clusterAgentTypeHash = utils.computeScriptHash(clusterAgentType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: clusterAgentTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'TransferClusterAgent',
+    value: {
+      clusterId: clusterAgentType.args.slice(0, 66),
+      from: {
+        type: 'Script',
+        value: clusterAgentInput!.cellOutput.lock,
+      },
+      to: {
+        type: 'Script',
+        value: clusterAgentOutput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: clusterAgentTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateTransferClusterAgentBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+  useCapacityMarginAsFee: boolean;
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateTransferClusterAgentAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: props.useCapacityMarginAsFee ? props.outputIndex : txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/clusterProxy/createClusterProxy.ts
+++ b/packages/core/src/cobuild/action/clusterProxy/createClusterProxy.ts
@@ -1,0 +1,77 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { injectNewClusterProxyOutput } from '../../../api';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+import { generateReferenceClusterAction } from '../cluster/referenceCluster';
+import { unpackToRawClusterProxyArgs } from '../../../codec';
+
+export function generateCreateClusterProxyAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+  reference: Awaited<ReturnType<typeof injectNewClusterProxyOutput>>['reference'];
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const clusterProxyOutput = txSkeleton.get('outputs').get(props.outputIndex);
+
+  const clusterProxyType = clusterProxyOutput!.cellOutput.type!;
+  const clusterProxyTypeHash = utils.computeScriptHash(clusterProxyType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: clusterProxyTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'CreateClusterProxy',
+    value: {
+      clusterId: clusterProxyOutput!.data,
+      clusterProxyId: unpackToRawClusterProxyArgs(clusterProxyType.args).id,
+      to: {
+        type: 'Script',
+        value: clusterProxyOutput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: clusterProxyTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  const clusterAction = generateReferenceClusterAction({
+    txSkeleton,
+    referenceType: props.reference.referenceType,
+    cluster: props.reference.cluster,
+  });
+  actions.push(...clusterAction.actions);
+  scriptInfos.push(...clusterAction.scriptInfos);
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateCreateClusterProxyBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+  reference: Awaited<ReturnType<typeof injectNewClusterProxyOutput>>['reference'];
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateCreateClusterProxyAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/clusterProxy/meltClusterProxy.ts
+++ b/packages/core/src/cobuild/action/clusterProxy/meltClusterProxy.ts
@@ -1,0 +1,65 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+import { unpackToRawClusterProxyArgs } from '../../../codec';
+
+export function generateMeltClusterProxyAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const clusterProxyInput = txSkeleton.get('inputs').get(props.inputIndex);
+
+  const clusterProxyType = clusterProxyInput!.cellOutput.type!;
+  const clusterProxyTypeHash = utils.computeScriptHash(clusterProxyType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: clusterProxyTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'MeltClusterProxy',
+    value: {
+      clusterId: clusterProxyInput!.data,
+      clusterProxyId: unpackToRawClusterProxyArgs(clusterProxyType.args).id,
+      from: {
+        type: 'Script',
+        value: clusterProxyInput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: clusterProxyTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateMeltClusterProxyBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateMeltClusterProxyAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/clusterProxy/referenceClusterProxy.ts
+++ b/packages/core/src/cobuild/action/clusterProxy/referenceClusterProxy.ts
@@ -1,0 +1,32 @@
+import { helpers } from '@ckb-lumos/lumos';
+import { UnpackResult } from '@ckb-lumos/codec';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { generateTransferClusterProxyAction } from './transferClusterProxy';
+
+export function generateReferenceClusterProxyAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  referenceType: 'payment' | 'cell';
+  clusterProxy?: {
+    inputIndex: number;
+    outputIndex: number;
+  };
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  if (props.referenceType === 'payment') {
+    return {
+      actions: [],
+      scriptInfos: [],
+    };
+  }
+  if (!props.clusterProxy) {
+    throw new Error('Cannot generate TransferClusterProxy Action without clusterProxy info');
+  }
+
+  return generateTransferClusterProxyAction({
+    txSkeleton: props.txSkeleton,
+    inputIndex: props.clusterProxy.inputIndex,
+    outputIndex: props.clusterProxy.outputIndex,
+  });
+}

--- a/packages/core/src/cobuild/action/clusterProxy/transferClusterProxy.ts
+++ b/packages/core/src/cobuild/action/clusterProxy/transferClusterProxy.ts
@@ -1,0 +1,73 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+import { unpackToRawClusterProxyArgs } from '../../../codec';
+
+export function generateTransferClusterProxyAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const clusterProxyInput = txSkeleton.get('inputs').get(props.inputIndex);
+  const clusterProxyOutput = txSkeleton.get('outputs').get(props.outputIndex);
+
+  const clusterProxyType = clusterProxyOutput!.cellOutput.type!;
+  const clusterProxyTypeHash = utils.computeScriptHash(clusterProxyType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: clusterProxyTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'TransferClusterProxy',
+    value: {
+      clusterId: clusterProxyOutput!.data,
+      clusterProxyId: unpackToRawClusterProxyArgs(clusterProxyType.args).id,
+      from: {
+        type: 'Script',
+        value: clusterProxyInput!.cellOutput.lock,
+      },
+      to: {
+        type: 'Script',
+        value: clusterProxyOutput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: clusterProxyTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateTransferClusterProxyBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+  useCapacityMarginAsFee: boolean;
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateTransferClusterProxyAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: props.useCapacityMarginAsFee ? props.outputIndex : txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/spore/createSpore.ts
+++ b/packages/core/src/cobuild/action/spore/createSpore.ts
@@ -1,0 +1,90 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { injectNewSporeOutput } from '../../../api';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+import { generateReferenceClusterAction } from '../cluster/referenceCluster';
+import { generateReferenceClusterAgentAction } from '../clusterAgent/referenceClusterAgent';
+
+export function generateCreateSporeAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+  reference: Awaited<ReturnType<typeof injectNewSporeOutput>>['reference'];
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const sporeOutput = txSkeleton.get('outputs').get(props.outputIndex);
+
+  const sporeType = sporeOutput!.cellOutput.type!;
+  const sporeTypeHash = utils.computeScriptHash(sporeType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: sporeTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'CreateSpore',
+    value: {
+      sporeId: sporeType.args,
+      dataHash: utils.ckbHash(sporeOutput!.data),
+      to: {
+        type: 'Script',
+        value: sporeOutput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: sporeTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  if (props.reference.referenceTarget === 'clusterAgent') {
+    const clusterAction = generateReferenceClusterAgentAction({
+      txSkeleton,
+      referenceType: props.reference.referenceType!,
+      clusterAgent: props.reference.clusterAgent,
+    });
+
+    actions.push(...clusterAction.actions);
+    scriptInfos.push(...clusterAction.scriptInfos);
+  }
+  if (props.reference.referenceTarget === 'cluster') {
+    const clusterAction = generateReferenceClusterAction({
+      txSkeleton,
+      referenceType: props.reference.referenceType!,
+      cluster: props.reference.cluster,
+    });
+
+    actions.push(...clusterAction.actions);
+    scriptInfos.push(...clusterAction.scriptInfos);
+  }
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateCreateSporeBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+  reference: Awaited<ReturnType<typeof injectNewSporeOutput>>['reference'];
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateCreateSporeAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/spore/meltSpore.ts
+++ b/packages/core/src/cobuild/action/spore/meltSpore.ts
@@ -1,0 +1,60 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+
+export function generateMeltSporeAction(props: { txSkeleton: helpers.TransactionSkeletonType; inputIndex: number }): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const sporeInput = txSkeleton.get('inputs').get(props.inputIndex);
+
+  const sporeType = sporeInput!.cellOutput.type!;
+  const sporeTypeHash = utils.computeScriptHash(sporeType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: sporeTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'MeltSpore',
+    value: {
+      sporeId: sporeType.args,
+      from: {
+        type: 'Script',
+        value: sporeInput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: sporeTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateMeltSporeBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateMeltSporeAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/action/spore/transferSpore.ts
+++ b/packages/core/src/cobuild/action/spore/transferSpore.ts
@@ -1,0 +1,71 @@
+import { helpers, utils } from '@ckb-lumos/lumos';
+import { bytes, UnpackResult } from '@ckb-lumos/codec';
+import { SporeAction } from '../../codec/sporeAction';
+import { Action, ScriptInfo } from '../../codec/buildingPacket';
+import { createRawBuildingPacket } from '../../base/buildingPacket';
+import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
+
+export function generateTransferSporeAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  const actions: UnpackResult<typeof Action>[] = [];
+  const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
+
+  let txSkeleton = props.txSkeleton;
+  const sporeInput = txSkeleton.get('inputs').get(props.inputIndex);
+  const sporeOutput = txSkeleton.get('outputs').get(props.outputIndex);
+
+  const sporeType = sporeOutput!.cellOutput.type!;
+  const sporeTypeHash = utils.computeScriptHash(sporeType);
+  const scriptInfo = createSporeScriptInfoFromTemplate({
+    scriptHash: sporeTypeHash,
+  });
+  scriptInfos.push(scriptInfo);
+
+  const actionData = SporeAction.pack({
+    type: 'TransferSpore',
+    value: {
+      sporeId: sporeType.args,
+      from: {
+        type: 'Script',
+        value: sporeInput!.cellOutput.lock,
+      },
+      to: {
+        type: 'Script',
+        value: sporeOutput!.cellOutput.lock,
+      },
+    },
+  });
+  actions.push({
+    scriptInfoHash: utils.ckbHash(ScriptInfo.pack(scriptInfo)),
+    scriptHash: sporeTypeHash,
+    data: bytes.hexify(actionData),
+  });
+
+  return {
+    actions,
+    scriptInfos,
+  };
+}
+
+export function generateTransferSporeBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+  useCapacityMarginAsFee: boolean;
+}) {
+  let txSkeleton = props.txSkeleton;
+
+  const action = generateTransferSporeAction(props);
+  return createRawBuildingPacket({
+    txSkeleton,
+    actions: action.actions,
+    scriptInfos: action.scriptInfos,
+    changeOutput: props.useCapacityMarginAsFee ? props.outputIndex : txSkeleton.get('outputs').size - 1,
+  });
+}

--- a/packages/core/src/cobuild/base/buildingPacket.ts
+++ b/packages/core/src/cobuild/base/buildingPacket.ts
@@ -1,0 +1,26 @@
+import { helpers } from '@ckb-lumos/lumos';
+import { UnpackResult } from '@ckb-lumos/codec';
+import { ActionVec, BuildingPacket, ScriptInfoVec } from '../codec/buildingPacket';
+import { inputCellsToResolvedInputs } from './resolvedInputs';
+
+export function createRawBuildingPacket(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  scriptInfos?: UnpackResult<typeof ScriptInfoVec>;
+  actions?: UnpackResult<typeof ActionVec>;
+  changeOutput?: number;
+}): UnpackResult<typeof BuildingPacket> {
+  const txSkeleton = props.txSkeleton;
+  return {
+    type: 'BuildingPacketV1',
+    value: {
+      message: {
+        actions: props.actions ?? [],
+      },
+      payload: helpers.createTransactionFromSkeleton(txSkeleton),
+      resolvedInputs: inputCellsToResolvedInputs(txSkeleton.get('inputs')),
+      changeOutput: props.changeOutput ?? txSkeleton.get('outputs').size - 1,
+      scriptInfos: props.scriptInfos ?? [],
+      lockActions: [],
+    },
+  };
+}

--- a/packages/core/src/cobuild/base/resolvedInputs.ts
+++ b/packages/core/src/cobuild/base/resolvedInputs.ts
@@ -1,0 +1,38 @@
+import { List } from 'immutable';
+import { Cell, Input } from '@ckb-lumos/lumos';
+import { UnpackResult } from '@ckb-lumos/codec';
+import { ResolvedInputs } from '../codec/buildingPacket';
+
+export function inputCellsToResolvedInputs(
+  inputs: List<Cell>,
+  filter?: (value: Cell, index: number, iter: List<Cell>) => boolean,
+): UnpackResult<typeof ResolvedInputs> {
+  if (filter instanceof Function) {
+    inputs = inputs.filter(filter);
+  }
+
+  return inputs.reduce<UnpackResult<typeof ResolvedInputs>>(
+    (sum, input) => {
+      sum.outputs.push(input.cellOutput);
+      sum.outputsData.push(input.data);
+      return sum;
+    },
+    {
+      outputs: [],
+      outputsData: [],
+    },
+  );
+}
+
+export function resolvedInputsToInputCells(
+  inputs: Input[],
+  resolvedInputs: UnpackResult<typeof ResolvedInputs>,
+): Cell[] {
+  return inputs.map((input, index) => {
+    return {
+      cellOutput: resolvedInputs.outputs[index],
+      data: resolvedInputs.outputsData[index],
+      outPoint: input.previousOutput,
+    };
+  });
+}

--- a/packages/core/src/cobuild/base/sporeScriptInfo.ts
+++ b/packages/core/src/cobuild/base/sporeScriptInfo.ts
@@ -1,0 +1,127 @@
+import { Hash } from '@ckb-lumos/base';
+import { UnpackResult } from '@ckb-lumos/codec';
+import { PackParam } from '@ckb-lumos/codec/src/base';
+import { ScriptInfo } from '../codec/buildingPacket';
+
+export const sporeScriptInfoMessageType = 'SporeAction';
+
+export const sporeScriptInfoSchema = `
+array Byte32 [byte; 32];
+vector Bytes <byte>;
+
+table Script {
+    code_hash: Byte32,
+    hash_type: byte,
+    args: Bytes,
+}
+
+union Address {
+    Script,
+}
+
+/* Actions for Spore */
+
+table MintSpore {
+    spore_id: Byte32,
+    to: Address,
+    data_hash: Byte32,
+}
+
+table TransferSpore {
+    spore_id: Byte32,
+    from: Address,
+    to: Address,
+}
+
+table BurnSpore {
+    spore_id: Byte32,
+    from: Address,
+}
+
+/* Actions for Cluster */
+
+table MintCluster {
+    cluster_id: Byte32,
+    to: Address,
+    data_hash: Byte32,
+}
+
+table TransferCluster {
+    cluster_id: Byte32,
+    from: Address,
+    to: Address,
+}
+
+/* Actions for Cluster/Proxy */
+
+table MintProxy {
+    cluster_id: Byte32,
+    proxy_id: Byte32,
+    to: Address,
+}
+
+table TransferProxy {
+    cluster_id: Byte32,
+    proxy_id: Byte32,
+    from: Address,
+    to: Address,
+}
+
+table BurnProxy {
+    cluster_id: Byte32,
+    proxy_id: Byte32,
+    from: Address,
+}
+
+/* Actions for Cluster/Agent */
+
+table MintAgent {
+    cluster_id: Byte32,
+    proxy_id: Byte32,
+    to: Address,
+}
+
+table TransferAgent {
+    cluster_id: Byte32,
+    from: Address,
+    to: Address,
+}
+
+table BurnAgent {
+    cluster_id: Byte32,
+    from: Address,
+}
+
+/* Action in ScriptInfo */
+
+union SporeAction {
+    MintSpore,
+    TransferSpore,
+    BurnSpore,
+
+    MintCluster,
+    TransferCluster,
+
+    MintProxy,
+    TransferProxy,
+    BurnProxy,
+
+    MintAgent,
+    TransferAgent,
+    BurnAgent,
+}
+`;
+
+export const sporeScriptInfoTemplate: Omit<PackParam<typeof ScriptInfo>, 'scriptHash'> = {
+  name: 'spore',
+  url: 'https://spore.pro',
+  schema: sporeScriptInfoSchema,
+  messageType: sporeScriptInfoMessageType,
+};
+
+export function createSporeScriptInfoFromTemplate(props: { scriptHash: Hash }): UnpackResult<typeof ScriptInfo> {
+  return {
+    ...sporeScriptInfoTemplate,
+    scriptHash: props.scriptHash,
+  };
+}

--- a/packages/core/src/cobuild/base/witnessLayout.ts
+++ b/packages/core/src/cobuild/base/witnessLayout.ts
@@ -1,0 +1,84 @@
+import { helpers } from '@ckb-lumos/lumos';
+import { blockchain } from '@ckb-lumos/base';
+import { bytes, BytesLike, number, UnpackResult } from '@ckb-lumos/codec';
+import { WitnessLayout, WitnessLayoutFieldTags } from '../codec/witnessLayout';
+import { ActionVec } from '../codec/buildingPacket';
+
+export function getWitnessType(witness?: BytesLike) {
+  const buf = bytes.bytify(witness ?? []);
+  if (buf.length > 4) {
+    const typeIndex = number.Uint32LE.unpack(buf.slice(0, 4));
+    if (typeIndex >= WitnessLayoutFieldTags.SighashAll) {
+      for (const [name, index] of Object.entries(WitnessLayoutFieldTags)) {
+        if (index === typeIndex) {
+          return name;
+        }
+      }
+    } else {
+      return 'WitnessArgs';
+    }
+  }
+
+  throw new Error('Unknown witness format');
+}
+
+export function unpackWitness(witness?: BytesLike) {
+  const buf = bytes.bytify(witness ?? []);
+  if (buf.length > 4) {
+    const typeIndex = number.Uint32LE.unpack(buf.slice(0, 4));
+    try {
+      if (typeIndex >= WitnessLayoutFieldTags.SighashAll) {
+        return WitnessLayout.unpack(buf);
+      } else {
+        return {
+          type: 'WitnessArgs',
+          value: blockchain.WitnessArgs.unpack(buf),
+        };
+      }
+    } catch (_err) {
+      // passthrough
+    }
+  }
+
+  throw new Error('Unknown witness format');
+}
+
+export function injectCommonCobuildProof(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  actions: UnpackResult<typeof ActionVec>;
+}): {
+  txSkeleton: helpers.TransactionSkeletonType;
+  witnessIndex: number;
+} {
+  let txSkeleton = props.txSkeleton;
+
+  // TODO: add Cobuild witness-check: If it's in legacy mode, manually add WitnessLayout
+  if (txSkeleton.get('inputs').size > 0) {
+    // Generate WitnessLayout
+    const witness = bytes.hexify(
+      WitnessLayout.pack({
+        type: 'SighashAll',
+        value: {
+          seal: '0x',
+          message: {
+            actions: props.actions,
+          },
+        },
+      }),
+    );
+
+    // Append the witness to the end of the witnesses
+    let witnessIndex: number | undefined;
+    txSkeleton = txSkeleton.update('witnesses', (witnesses) => {
+      witnessIndex = witnesses.size;
+      return witnesses.push(witness);
+    });
+
+    return {
+      txSkeleton,
+      witnessIndex: witnessIndex!,
+    };
+  }
+
+  throw new Error('Cannot inject CobuildProof into a Transaction without witnesses');
+}

--- a/packages/core/src/cobuild/codec/buildingPacket.ts
+++ b/packages/core/src/cobuild/codec/buildingPacket.ts
@@ -1,0 +1,61 @@
+import { molecule } from '@ckb-lumos/codec';
+import { blockchain } from '@ckb-lumos/base';
+import { Hash, RawString, Uint32Opt } from '../../codec';
+
+export const Action = molecule.table(
+  {
+    scriptInfoHash: Hash,
+    scriptHash: Hash,
+    data: blockchain.Bytes,
+  },
+  ['scriptInfoHash', 'scriptHash', 'data'],
+);
+
+export const ActionVec = molecule.vector(Action);
+
+export const Message = molecule.table(
+  {
+    actions: ActionVec,
+  },
+  ['actions'],
+);
+
+export const ResolvedInputs = molecule.table(
+  {
+    outputs: blockchain.CellOutputVec,
+    outputsData: blockchain.BytesVec,
+  },
+  ['outputs', 'outputsData'],
+);
+
+export const ScriptInfo = molecule.table(
+  {
+    name: RawString,
+    url: RawString,
+    scriptHash: Hash,
+    schema: RawString,
+    messageType: RawString,
+  },
+  ['name', 'url', 'scriptHash', 'schema', 'messageType'],
+);
+
+export const ScriptInfoVec = molecule.vector(ScriptInfo);
+
+export const BuildingPacketV1 = molecule.table(
+  {
+    message: Message,
+    payload: blockchain.Transaction,
+    resolvedInputs: ResolvedInputs,
+    changeOutput: Uint32Opt,
+    scriptInfos: ScriptInfoVec,
+    lockActions: ActionVec,
+  },
+  ['message', 'payload', 'resolvedInputs', 'changeOutput', 'scriptInfos', 'lockActions'],
+);
+
+export const BuildingPacket = molecule.union(
+  {
+    BuildingPacketV1,
+  },
+  ['BuildingPacketV1'],
+);

--- a/packages/core/src/cobuild/codec/sporeAction.ts
+++ b/packages/core/src/cobuild/codec/sporeAction.ts
@@ -1,0 +1,152 @@
+import { molecule } from '@ckb-lumos/codec';
+import { blockchain } from '@ckb-lumos/base';
+import { Hash } from '../../codec';
+
+export const Address = molecule.union(
+  {
+    Script: blockchain.Script,
+  },
+  ['Script'],
+);
+
+/**
+ * Spore
+ */
+export const CreateSpore = molecule.table(
+  {
+    sporeId: Hash,
+    to: Address,
+    dataHash: Hash,
+  },
+  ['sporeId', 'to', 'dataHash'],
+);
+export const TransferSpore = molecule.table(
+  {
+    sporeId: Hash,
+    from: Address,
+    to: Address,
+  },
+  ['sporeId', 'from', 'to'],
+);
+export const MeltSpore = molecule.table(
+  {
+    sporeId: Hash,
+    from: Address,
+  },
+  ['sporeId', 'from'],
+);
+
+/**
+ * Cluster
+ */
+export const CreateCluster = molecule.table(
+  {
+    clusterId: Hash,
+    to: Address,
+    dataHash: Hash,
+  },
+  ['clusterId', 'to', 'dataHash'],
+);
+export const TransferCluster = molecule.table(
+  {
+    clusterId: Hash,
+    from: Address,
+    to: Address,
+  },
+  ['clusterId', 'from', 'to'],
+);
+
+/**
+ * ClusterProxy
+ */
+export const CreateClusterProxy = molecule.table(
+  {
+    clusterId: Hash,
+    clusterProxyId: Hash,
+    to: Address,
+  },
+  ['clusterId', 'clusterProxyId', 'to'],
+);
+export const TransferClusterProxy = molecule.table(
+  {
+    clusterId: Hash,
+    clusterProxyId: Hash,
+    from: Address,
+    to: Address,
+  },
+  ['clusterId', 'clusterProxyId', 'from', 'to'],
+);
+export const MeltClusterProxy = molecule.table(
+  {
+    clusterId: Hash,
+    clusterProxyId: Hash,
+    from: Address,
+  },
+  ['clusterId', 'clusterProxyId', 'from'],
+);
+
+/**
+ * ClusterAgent
+ */
+export const CreateClusterAgent = molecule.table(
+  {
+    clusterId: Hash,
+    clusterProxyId: Hash,
+    to: Address,
+  },
+  ['clusterId', 'clusterProxyId', 'to'],
+);
+export const TransferClusterAgent = molecule.table(
+  {
+    clusterId: Hash,
+    from: Address,
+    to: Address,
+  },
+  ['clusterId', 'from', 'to'],
+);
+export const MeltClusterAgent = molecule.table(
+  {
+    clusterId: Hash,
+    from: Address,
+  },
+  ['clusterId', 'from'],
+);
+
+/**
+ * Spore ScriptInfo Actions
+ */
+export const SporeAction = molecule.union(
+  {
+    // Spore
+    CreateSpore,
+    TransferSpore,
+    MeltSpore,
+
+    // Cluster
+    CreateCluster,
+    TransferCluster,
+
+    // ClusterProxy
+    CreateClusterProxy,
+    TransferClusterProxy,
+    MeltClusterProxy,
+
+    // ClusterAgent
+    CreateClusterAgent,
+    TransferClusterAgent,
+    MeltClusterAgent,
+  },
+  [
+    'CreateSpore',
+    'TransferSpore',
+    'MeltSpore',
+    'CreateCluster',
+    'TransferCluster',
+    'CreateClusterProxy',
+    'TransferClusterProxy',
+    'MeltClusterProxy',
+    'CreateClusterAgent',
+    'TransferClusterAgent',
+    'MeltClusterAgent',
+  ],
+);

--- a/packages/core/src/cobuild/codec/witnessLayout.ts
+++ b/packages/core/src/cobuild/codec/witnessLayout.ts
@@ -1,0 +1,40 @@
+import { blockchain } from '@ckb-lumos/base';
+import { molecule } from '@ckb-lumos/codec';
+import { Message } from './buildingPacket';
+
+export const SighashAll = molecule.table(
+  {
+    seal: blockchain.Bytes,
+    message: Message,
+  },
+  ['seal', 'message'],
+);
+export const SighashAllOnly = molecule.table(
+  {
+    seal: blockchain.Bytes,
+  },
+  ['seal'],
+);
+
+/**
+ * Otx related are not implemented yet, so just placeholders.
+ */
+export const Otx = molecule.table({}, []);
+export const OtxStart = molecule.table({}, []);
+
+export const WitnessLayoutFieldTags = {
+  SighashAll: 4278190081,
+  SighashAllOnly: 4278190082,
+  Otx: 4278190083,
+  OtxStart: 4278190084,
+} as const;
+
+export const WitnessLayout = molecule.union(
+  {
+    SighashAll,
+    SighashAllOnly,
+    Otx,
+    OtxStart,
+  },
+  WitnessLayoutFieldTags,
+);

--- a/packages/core/src/cobuild/index.ts
+++ b/packages/core/src/cobuild/index.ts
@@ -1,0 +1,23 @@
+export * from './base/buildingPacket';
+export * from './base/resolvedInputs';
+export * from './base/sporeScriptInfo';
+export * from './base/witnessLayout';
+
+export * from './codec/buildingPacket';
+export * from './codec/witnessLayout';
+export * from './codec/sporeAction';
+
+export * from './action/spore/createSpore';
+export * from './action/spore/transferSpore';
+export * from './action/spore/meltSpore';
+export * from './action/cluster/createCluster';
+export * from './action/cluster/transferCluster';
+export * from './action/cluster/referenceCluster';
+export * from './action/clusterProxy/createClusterProxy';
+export * from './action/clusterProxy/transferClusterProxy';
+export * from './action/clusterProxy/referenceClusterProxy';
+export * from './action/clusterProxy/meltClusterProxy';
+export * from './action/clusterAgent/createClusterAgent';
+export * from './action/clusterAgent/transferClusterAgent';
+export * from './action/clusterAgent/referenceClusterAgent';
+export * from './action/clusterAgent/meltClusterAgent';

--- a/packages/core/src/codec/utils.ts
+++ b/packages/core/src/codec/utils.ts
@@ -1,5 +1,6 @@
-import { molecule, number } from '@ckb-lumos/codec';
 import { blockchain } from '@ckb-lumos/base';
+import { BytesLike, molecule, number } from '@ckb-lumos/codec';
+import { bufferToRawString, bytifyRawString } from '../helpers';
 
 export const ScriptId = molecule.struct(
   {
@@ -9,6 +10,16 @@ export const ScriptId = molecule.struct(
   ['codeHash', 'hashType'],
 );
 
-export const ScriptIdOpt = molecule.option(ScriptId);
-
 export const Uint8Opt = molecule.option(number.Uint8);
+export const Uint32Opt = molecule.option(number.Uint32LE);
+
+export const Hash = blockchain.Byte32;
+
+/**
+ * The codec for packing/unpacking UTF-8 raw strings.
+ * Should be packed like so: String.pack('something')
+ */
+export const RawString = molecule.byteVecOf({
+  pack: (packable: string) => bytifyRawString(packable),
+  unpack: (unpackable: BytesLike) => bufferToRawString(unpackable),
+});

--- a/packages/core/src/config/cache.ts
+++ b/packages/core/src/config/cache.ts
@@ -8,8 +8,10 @@ const cacheStore: Map<Hash, SporeConfigCache> = new Map();
 export interface SporeConfigCache<T extends string = string> {
   hash: Hash;
   config: SporeConfig<T>;
-  scriptsByTag: Record<T, Record<string, SporeScript[]>>;
   scriptsByCodeHash: Record<Hash, SporeCategorizedScript>;
+  scriptsByTag: Record<T, Record<string, SporeCategorizedScript[]>>;
+  scriptsByTags: Record<T, Record<string, SporeCategorizedScript[]>>;
+  queryRecordsByTags: Record<T, Record<string, SporeCategorizedScript[]>>;
 }
 
 export interface SporeCategorizedScript extends SporeScript {
@@ -45,49 +47,106 @@ export function getSporeConfigCache<T extends string>(config: SporeConfig<T>): S
 export function createSporeConfigCache<T extends string>(config: SporeConfig<T>): SporeConfigCache<T> {
   const hash = getSporeConfigHash(config);
 
-  const scriptsByTag = {} as Record<T, Record<string, SporeScript[]>>;
   const scriptsByCodeHash = {} as Record<Hash, SporeCategorizedScript>;
+  const scriptsByTag = {} as Record<T, Record<string, SporeCategorizedScript[]>>;
+  const scriptsByTags = {} as Record<T, Record<string, SporeCategorizedScript[]>>;
+  const queryRecordsByTags = {} as Record<T, Record<string, SporeCategorizedScript[]>>;
 
   for (const scriptName in config.scripts) {
     const scriptCategory = config.scripts[scriptName];
-    const scriptTagMap = {} as Record<string, SporeScript[]>;
+    const scriptTagMap = {} as Record<string, SporeCategorizedScript[]>;
+    const scriptTagsMap = {} as Record<string, SporeCategorizedScript[]>;
 
     for (const script of scriptCategory.versions) {
-      scriptsByCodeHash[script.script.codeHash] = {
+      const categorizedScript: SporeCategorizedScript = {
         name: scriptName,
         ...cloneDeep(script),
       };
-      for (const tag of script.tags) {
-        if (scriptTagMap[tag] === void 0) scriptTagMap[tag] = [];
-        scriptTagMap[tag].push(script);
+      scriptsByCodeHash[script.script.codeHash] = categorizedScript;
+      const tags = script.tags.sort();
+      for (const tag of tags) {
+        if (scriptTagMap[tag] === void 0) {
+          scriptTagMap[tag] = [];
+        }
+        scriptTagMap[tag].push(categorizedScript);
       }
+      const combinedTags = tags.join(',');
+      if (!scriptTagsMap[combinedTags]) {
+        scriptTagsMap[combinedTags] = [];
+      }
+      scriptTagsMap[combinedTags].push(categorizedScript);
     }
 
     scriptsByTag[scriptName] = scriptTagMap;
+    scriptsByTags[scriptName] = scriptTagsMap;
+    queryRecordsByTags[scriptName] = {};
   }
 
   return {
     hash,
     config,
     scriptsByTag,
+    scriptsByTags,
     scriptsByCodeHash,
+    queryRecordsByTags,
   };
 }
 
 /**
- * Search for a specific list of SporeScripts by "scriptName" and "tag" in a SporeCache.
+ * Search for a specific list of SporeScripts by "scriptName" and "tag" in a SporeConfigCache.
  */
 export function getSporeCacheScriptsByTag<T extends string>(
   cache: SporeConfigCache<T>,
   scriptName: T,
   tag: string,
-): SporeScript[] | undefined {
+): SporeCategorizedScript[] | undefined {
   const scripts = cache.scriptsByTag[scriptName]?.[tag];
   if (!Array.isArray(scripts)) {
     return void 0;
   }
 
   return scripts;
+}
+
+/**
+ * Search SporeConfig by "scriptName" and "tags" in a SporeConfigCache.
+ */
+export function getSporeCacheScriptsByTags<T extends string>(
+  cache: SporeConfigCache<T>,
+  scriptName: T,
+  tags: string[],
+): SporeCategorizedScript[] | undefined {
+  if (tags.length === 1) {
+    return getSporeCacheScriptsByTag(cache, scriptName, tags[0]);
+  }
+
+  const recordsMap: Record<string, SporeCategorizedScript[]> = cache.queryRecordsByTags[scriptName];
+  const sortedTags = tags.sort();
+  const key = sortedTags.join(',');
+  if (recordsMap && key in recordsMap) {
+    return recordsMap[key];
+  }
+
+  const scriptsMap = cache.scriptsByTags[scriptName];
+  if (!scriptsMap) {
+    return void 0;
+  }
+
+  const patterns = sortedTags.join(',.*');
+  const regex = new RegExp(`${patterns}.*`, 'g');
+  const match = Object.entries(scriptsMap).filter(([_tags]) => {
+    return regex.test(_tags);
+  });
+  if (match) {
+    const matchScripts = match.reduce((matches, [_, scripts]) => {
+      matches.push(...scripts);
+      return matches;
+    }, [] as SporeCategorizedScript[]);
+    recordsMap[key] = matchScripts;
+    return matchScripts;
+  }
+
+  return void 0;
 }
 
 /**

--- a/packages/core/src/config/predefined.ts
+++ b/packages/core/src/config/predefined.ts
@@ -8,6 +8,7 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
   ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
   ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
   maxTransactionSize: 500 * 1024, // 500 KB
+  defaultTags: ['v2'],
   scripts: {
     Spore: {
       versions: [
@@ -24,9 +25,13 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
             },
             depType: 'code',
           },
+          behaviors: {
+            lockProxy: true,
+            cobuild: true,
+          },
         },
         {
-          tags: ['v1'],
+          tags: ['v1', 'latest'],
           script: {
             codeHash: '0xbbad126377d45f90a8ee120da988a2d7332c78ba8fd679aab478a19d6c133494',
             hashType: 'data1',
@@ -56,9 +61,13 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
             },
             depType: 'code',
           },
+          behaviors: {
+            lockProxy: true,
+            cobuild: true,
+          },
         },
         {
-          tags: ['v1'],
+          tags: ['v1', 'latest'],
           script: {
             codeHash: '0x598d793defef36e2eeba54a9b45130e4ca92822e1d193671f490950c3b856080',
             hashType: 'data1',
@@ -88,6 +97,10 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
             },
             depType: 'code',
           },
+          behaviors: {
+            lockProxy: true,
+            cobuild: true,
+          },
         },
       ],
     },
@@ -106,6 +119,10 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
             },
             depType: 'code',
           },
+          behaviors: {
+            lockProxy: true,
+            cobuild: true,
+          },
         },
       ],
     },
@@ -123,6 +140,10 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
               index: '0x0',
             },
             depType: 'code',
+          },
+          behaviors: {
+            lockProxy: true,
+            cobuild: true,
           },
         },
       ],

--- a/packages/core/src/config/script.ts
+++ b/packages/core/src/config/script.ts
@@ -1,6 +1,6 @@
 import { ScriptId } from '../types';
 import { SporeConfig, SporeScript, SporeScriptCategory } from './types';
-import { getSporeConfigCache, getSporeCacheScriptByCodeHash } from './cache';
+import { getSporeConfigCache, getSporeCacheScriptByCodeHash, getSporeCacheScriptsByTags } from './cache';
 
 /**
  * Get a specific SporeScriptCategory from SporeConfig by "scriptName".
@@ -16,29 +16,80 @@ export function getSporeScriptCategory(config: SporeConfig, scriptName: string):
 }
 
 /**
- * Get a specific SporeScript from SporeConfig by "scriptName" and or "scriptId".
+ * Get a specific SporeScript from SporeConfig by "scriptName" with optional "scriptId" or "tags".
  * Throws an error if the script doesn't exist.
  */
-export function getSporeScript(config: SporeConfig, scriptName: string, scriptId?: ScriptId): SporeScript {
+export function getSporeScript(config: SporeConfig, scriptName: string): SporeScript;
+export function getSporeScript(config: SporeConfig, scriptName: string, tags: string[]): SporeScript;
+export function getSporeScript(config: SporeConfig, scriptName: string, scriptId: ScriptId): SporeScript;
+export function getSporeScript(config: SporeConfig, scriptName: string, extraArg?: unknown): SporeScript {
+  if (extraArg && typeof extraArg === 'object' && 'codeHash' in extraArg && 'hashType' in extraArg) {
+    return getSporeScriptByScriptId(config, scriptName, extraArg as ScriptId);
+  }
+  if (extraArg && Array.isArray(extraArg)) {
+    return getSporeScriptByTags(config, scriptName, extraArg as string[]);
+  }
+  if (config.defaultTags) {
+    return getSporeScriptByTags(config, scriptName, config.defaultTags);
+  }
+
+  return getLatestSporeScript(config, scriptName);
+}
+
+/**
+ * Get a specific SporeScript from SporeConfig by "scriptName".
+ * Throws an error if the script doesn't exist.
+ */
+export function getLatestSporeScript(config: SporeConfig, scriptName: string): SporeScript {
+  const scriptCategory = config.scripts[scriptName];
+  if (!scriptCategory || !scriptCategory.versions.length) {
+    throw new Error(`"${scriptName}" script is not defined in the SporeConfig`);
+  }
+
+  return scriptCategory.versions[0];
+}
+
+/**
+ * Get a specific SporeScript from SporeConfig by "scriptName" and "scriptId".
+ * Throws an error if the script doesn't exist.
+ */
+export function getSporeScriptByScriptId(config: SporeConfig, scriptName: string, scriptId: ScriptId) {
   const scriptCategory = config.scripts[scriptName];
   if (!scriptCategory || !scriptCategory.versions.length) {
     throw new Error(`"${scriptName}" script is not defined in the SporeConfig`);
   }
 
   const cache = getSporeConfigCache(config);
-
-  // Find a specific version of the script
-  if (scriptId) {
-    const script = getSporeCacheScriptByCodeHash(cache, scriptId.codeHash, scriptName);
-    if (!script) {
-      throw new Error(`Specific version of the "${scriptName}" script is not defined in the SporeConfig`);
-    }
-
-    return script;
+  const script = getSporeCacheScriptByCodeHash(cache, scriptId.codeHash, scriptName);
+  if (!script) {
+    throw new Error(
+      `Specific "${scriptName}" script is not defined in the SporeConfig, codeHash: ${scriptId.codeHash}`,
+    );
   }
 
-  // Returns the latest version of the script
-  return scriptCategory.versions[0];
+  return script;
+}
+
+/**
+ * Get a specific SporeScript from SporeConfig by "scriptName" and "scriptId".
+ * Throws an error if the script doesn't exist.
+ */
+export function getSporeScriptByTags(config: SporeConfig, scriptName: string, tags: string[]): SporeScript {
+  const scriptCategory = config.scripts[scriptName];
+  if (!scriptCategory || !scriptCategory.versions.length) {
+    throw new Error(`"${scriptName}" script is not defined in the SporeConfig`);
+  }
+
+  const cache = getSporeConfigCache(config);
+  const scripts = getSporeCacheScriptsByTags(cache, scriptName, tags);
+  if (!scripts || !scripts.length) {
+    throw new Error(
+      `Specific tags of the "${scriptName}" script is not defined in the SporeConfig: [${tags.join(', ')}]`,
+    );
+  }
+
+  // Returns the latest version of the script (the first one in the list)
+  return scripts[0];
 }
 
 /**

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -7,6 +7,7 @@ export interface SporeConfig<T extends string = string> {
   ckbNodeUrl: string;
   ckbIndexerUrl: string;
   maxTransactionSize?: number;
+  defaultTags?: string[];
   scripts: SporeScriptCategories<T>;
 }
 
@@ -23,7 +24,13 @@ export interface SporeVersionedScript extends SporeScript {
 export type SporeScripts<T extends string> = Record<T, SporeScript>;
 
 export interface SporeScript {
+  tags: string[];
   script: ScriptId;
   cellDep: CellDep;
-  tags: string[];
+  behaviors?: SporeScriptOptions;
+}
+
+export interface SporeScriptOptions {
+  lockProxy?: boolean;
+  cobuild?: boolean;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,21 +39,6 @@ importers:
 
   examples/acp:
     dependencies:
-      '@ckb-lumos/base':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/bi':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/codec':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/common-scripts':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/lumos':
-        specifier: ^0.21.1
-        version: 0.21.1
       '@spore-examples/shared':
         specifier: workspace:^
         version: link:../shared
@@ -66,24 +51,6 @@ importers:
 
   examples/omnilock:
     dependencies:
-      '@ckb-lumos/base':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/bi':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/codec':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/common-scripts':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/config-manager':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/lumos':
-        specifier: ^0.21.1
-        version: 0.21.1
       '@spore-examples/shared':
         specifier: workspace:^
         version: link:../shared
@@ -99,18 +66,6 @@ importers:
 
   examples/secp256k1:
     dependencies:
-      '@ckb-lumos/base':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/bi':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/common-scripts':
-        specifier: ^0.21.1
-        version: 0.21.1
-      '@ckb-lumos/lumos':
-        specifier: ^0.21.1
-        version: 0.21.1
       '@spore-examples/shared':
         specifier: workspace:^
         version: link:../shared
@@ -126,26 +81,26 @@ importers:
   packages/core:
     dependencies:
       '@ckb-lumos/base':
-        specifier: ^0.21.1
-        version: 0.21.1
+        specifier: ^0.22.0-next.2
+        version: 0.22.0-next.2
       '@ckb-lumos/bi':
-        specifier: ^0.21.1
-        version: 0.21.1
+        specifier: ^0.22.0-next.2
+        version: 0.22.0-next.2
       '@ckb-lumos/codec':
-        specifier: ^0.21.1
-        version: 0.21.1
+        specifier: ^0.22.0-next.2
+        version: 0.22.0-next.2
       '@ckb-lumos/common-scripts':
-        specifier: ^0.21.1
-        version: 0.21.1
+        specifier: ^0.22.0-next.2
+        version: 0.22.0-next.2
       '@ckb-lumos/config-manager':
-        specifier: ^0.21.1
-        version: 0.21.1
+        specifier: ^0.22.0-next.2
+        version: 0.22.0-next.2
       '@ckb-lumos/lumos':
-        specifier: ^0.21.1
-        version: 0.21.1
+        specifier: ^0.22.0-next.2
+        version: 0.22.0-next.2
       '@ckb-lumos/rpc':
-        specifier: ^0.21.1
-        version: 0.21.1
+        specifier: ^0.22.0-next.2
+        version: 0.22.0-next.2
       '@exact-realty/multipart-parser':
         specifier: ^1.0.9
         version: 1.0.9
@@ -371,13 +326,13 @@ packages:
       prettier: 2.8.7
     dev: true
 
-  /@ckb-lumos/base@0.21.1:
-    resolution: {integrity: sha512-7O+jBl7pqMsRbYTMNnbpamgaQzvaLZq+ftMtnKZ3A+Zbs6hZcGbz/6nfbRZnyJitPXQHRPT5KAQz6g+TiYqJGg==}
+  /@ckb-lumos/base@0.22.0-next.2:
+    resolution: {integrity: sha512-41oCLYF854p38hLJ1CzWfaD8JywJGxgGQ8xuC9HNeChajZYI1DXWayFE41emF7FlXyI+ItwxMihcvUEEOBX/lg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.21.1
-      '@ckb-lumos/codec': 0.21.1
-      '@ckb-lumos/toolkit': 0.21.1
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
       '@types/blake2b': 2.1.0
       '@types/lodash.isequal': 4.5.6
       blake2b: 2.1.4
@@ -385,68 +340,68 @@ packages:
       lodash.isequal: 4.5.0
     dev: false
 
-  /@ckb-lumos/bi@0.21.1:
-    resolution: {integrity: sha512-6q8uesvu3DAM7GReei9H5seino4tnakTeg8uXtZBPDC6rboMohLCPQvEwhl1iHmsybXvBYVQt4Te1BPPZtuaRw==}
+  /@ckb-lumos/bi@0.22.0-next.2:
+    resolution: {integrity: sha512-lbpAFPg2ihL0qPJm+gbR9R1tt421xjXIBnQ84YIYilb+hkclDYbd/J5EeA1yag/ggh5tqf5996/CpchG9BhXiQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       jsbi: 4.3.0
     dev: false
 
-  /@ckb-lumos/ckb-indexer@0.21.1:
-    resolution: {integrity: sha512-592pMVP3lwTXF7TmlOcayvGYKOhkYpjbLHUDo7By4yWbm7ZpdexaN5hn0X1sjJgMuee5prxGr9/fY684VTpJQw==}
+  /@ckb-lumos/ckb-indexer@0.22.0-next.2:
+    resolution: {integrity: sha512-Go4XuqgRo/G74hc9QOlBQhy0VGDJqFJ87NpRIBhGZgj82nPOXqEp+BZWG6wO/Vs4u7tPhuVicRDuIrCIG6DmxQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.21.1
-      '@ckb-lumos/bi': 0.21.1
-      '@ckb-lumos/codec': 0.21.1
-      '@ckb-lumos/rpc': 0.21.1
-      '@ckb-lumos/toolkit': 0.21.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
       cross-fetch: 3.1.8
       events: 3.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/codec@0.21.1:
-    resolution: {integrity: sha512-z6IUUxVZrx663iC7VM9CmaQZL8jsdM3ybgz0UCS24JgBXTNec+Uz0/Zrl7yeH6fBpVls44C2wObcHKigKaNVAA==}
+  /@ckb-lumos/codec@0.22.0-next.2:
+    resolution: {integrity: sha512-uBcMUDr7phIYhiP3yetee2IlChVPGdFHLYf+KlIN3Xsvw4ihs3t2/b0wJ3Aj4eCk03Zb/vyIBuGsGtx1phJrXA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.21.1
+      '@ckb-lumos/bi': 0.22.0-next.2
     dev: false
 
-  /@ckb-lumos/common-scripts@0.21.1:
-    resolution: {integrity: sha512-EfZQ9wdxPmEsxVVwtBjhpZVKbYCm1FJkMt59ABsIO1Ub7yi0qap7AQl0MMbuLwWIGKwS2w0U3wx/oJPm7z1RXg==}
+  /@ckb-lumos/common-scripts@0.22.0-next.2:
+    resolution: {integrity: sha512-zAqjreoWtJuGv+IucuJVh0fNsfWoXVCqUh3JBPMcKdGpqN02ZpTB2Dd1KGqC7ec/usky6HDTh0uoZEqFdCsC0Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.21.1
-      '@ckb-lumos/bi': 0.21.1
-      '@ckb-lumos/codec': 0.21.1
-      '@ckb-lumos/config-manager': 0.21.1
-      '@ckb-lumos/helpers': 0.21.1
-      '@ckb-lumos/rpc': 0.21.1
-      '@ckb-lumos/toolkit': 0.21.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/config-manager': 0.22.0-next.2
+      '@ckb-lumos/helpers': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
       immutable: 4.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/config-manager@0.21.1:
-    resolution: {integrity: sha512-BmrNqYyaksdCKHWagyC8+R8GUxhIO+sOM5S925jlkpjju2sUbH0Id2/zmdb7I9KxdKnbx3WsR+hqy7/bYqw1lA==}
+  /@ckb-lumos/config-manager@0.22.0-next.2:
+    resolution: {integrity: sha512-qwgbDEkgaqweQ87MvSk//Es88xLhAGgtrc5E0nAPFTUI9oDwZ1w4VeitIIaXg0K44dnYYI4511zcYbu39SR3kg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.21.1
-      '@ckb-lumos/bi': 0.21.1
-      '@ckb-lumos/codec': 0.21.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
       '@types/deep-freeze-strict': 1.1.0
       deep-freeze-strict: 1.1.1
     dev: false
 
-  /@ckb-lumos/hd@0.21.1:
-    resolution: {integrity: sha512-BnfpJf/sx/dJzL5BrOxPeKbKgv2x74KWd0xwjw1/gBQ2IMhu0S1mLwFsOT3Zu2nuhpQYvZGvr0cd3vD/SoMDow==}
+  /@ckb-lumos/hd@0.22.0-next.2:
+    resolution: {integrity: sha512-4qazlWkBfE1pb0F9TFptKL7fWA7NULHauTWrJ7v5qZphBVtj9XtL7uasQ0vqdAWzmIWmnkA9tUYdWcye1ujk6Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.21.1
-      '@ckb-lumos/bi': 0.21.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
       bn.js: 5.2.1
       elliptic: 6.5.4
       scrypt-js: 3.0.1
@@ -454,53 +409,83 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@ckb-lumos/helpers@0.21.1:
-    resolution: {integrity: sha512-jFN6DtWzwVNEY4kmnzczRaQqtyRJQwzAEuHRUQ0LqTiIGM+SlfgjH/l/InAG4cIhDOurMudnUJ4ex68wmbkhVw==}
+  /@ckb-lumos/helpers@0.22.0-next.2:
+    resolution: {integrity: sha512-VIoyJyF0fu2ts4Yp03CZZ5ALuNme7ZE2CA7d5SFsZH8bUFCkHbm6aWfCHiV2L9fW+t4uJZGrLYDOjxYLmoy6Lg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.21.1
-      '@ckb-lumos/bi': 0.21.1
-      '@ckb-lumos/codec': 0.21.1
-      '@ckb-lumos/config-manager': 0.21.1
-      '@ckb-lumos/toolkit': 0.21.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/config-manager': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
       bech32: 2.0.0
       immutable: 4.3.0
     dev: false
 
-  /@ckb-lumos/lumos@0.21.1:
-    resolution: {integrity: sha512-a5n8xaIUvmaPsw2fBki8Jamy6/6uQnLWDZM9SQX29cZ1YVoAk/slnBmEbCIGXmxDhcuAlLkTeJaiLDKEGrZ6pg==}
+  /@ckb-lumos/light-client@0.22.0-next.2:
+    resolution: {integrity: sha512-hFIs0E0ratMvoBRTWTQOaWh2Qsai+MmdQYXkMnuPdLTEYlKckHS5VnHVpLqYu8acnmlaTwjuF85ojZNUxM1WXQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.21.1
-      '@ckb-lumos/bi': 0.21.1
-      '@ckb-lumos/ckb-indexer': 0.21.1
-      '@ckb-lumos/common-scripts': 0.21.1
-      '@ckb-lumos/config-manager': 0.21.1
-      '@ckb-lumos/hd': 0.21.1
-      '@ckb-lumos/helpers': 0.21.1
-      '@ckb-lumos/rpc': 0.21.1
-      '@ckb-lumos/toolkit': 0.21.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      cross-fetch: 3.1.8
+      events: 3.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/rpc@0.21.1:
-    resolution: {integrity: sha512-gZWXYCyQ98s84Pb+buOiYL3HOIxQPLHQdCyo96GFerNw9lB1XsbaGWzfHPYpZvOQqYtnJ1GUfTkQkADrQ7hmew==}
+  /@ckb-lumos/lumos@0.22.0-next.2:
+    resolution: {integrity: sha512-aabZBF+B+F3Dyr2EW7xqWppmQNQYyMX4BdSrwGtOwDllby0/kM5f09CxyMf4Uk6En3rzMrh3z1SOQ94OVTzAQA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.21.1
-      '@ckb-lumos/bi': 0.21.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/common-scripts': 0.22.0-next.2
+      '@ckb-lumos/config-manager': 0.22.0-next.2
+      '@ckb-lumos/hd': 0.22.0-next.2
+      '@ckb-lumos/helpers': 0.22.0-next.2
+      '@ckb-lumos/light-client': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/transaction-manager': 0.22.0-next.2
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@ckb-lumos/rpc@0.22.0-next.2:
+    resolution: {integrity: sha512-V87fniKRI81XNIwesD9PIatj5D0WWUZYXnEjYFntnTXZ/w95B/uUIz2SqievU8oIMbFAMIzDIcVdpOcMMoZ9Aw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
       abort-controller: 3.0.0
       cross-fetch: 3.1.8
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/toolkit@0.21.1:
-    resolution: {integrity: sha512-awrFos7uQXEVGbqKSv/8Fc8B8XAfxdYoyYak4zFyAAmxxA0NiTTvk9V8TsOA7zVXpxct4Jal22+qUe+4Jg8T/g==}
+  /@ckb-lumos/toolkit@0.22.0-next.2:
+    resolution: {integrity: sha512-HHYRp0QwTSZHkzBGb3JAeDgOAPugibR5DnSrEAlq93RDBCX3Oy7WrE3R9BI3P6TmH5RAs0KKpMcVwVc9J1FJcQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.21.1
+      '@ckb-lumos/bi': 0.22.0-next.2
+    dev: false
+
+  /@ckb-lumos/transaction-manager@0.22.0-next.2:
+    resolution: {integrity: sha512-Wre1zWJDIDZxZz5eFosVcU+zodYSH3TrANCwldWxIXshZcHKyePkPf0SO9wcUas3pXHXtCqO/xe7FEfhLJj6Eg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
+      immutable: 4.3.0
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@cspotcode/source-map-support@0.8.1:


### PR DESCRIPTION
## Changes
- Added basic Cobuild support (no detailed tests yet, just trying to pass existing tests)
- Added a feature to filter SporeScripts by tags (which are predefined in the SporeConfig)
- Added script behavior checks, allowing enable/disable script features manually by updating the SporeConfig

## Features

### Basic Cobuild support

New APIs have been added to generate WitnessLayout and BuildingPacket. 

However, currently, the only noticeable change to the transaction is the addition of an extra witness at the end of the Transaction.witnesses. This is because we currently only support it with legacy locks that do not support WitnessLayout.

### Filter SporeScript by tags

Basically, each SporeScirpt should have a `tags` field. 
For example, this is a Spore script:
```js
{
  tags: ['v2', 'preview'],
  script: { ... },
  cellDep: { ... },
  behaviors: { ... },
}
```

The script can be found with the following code:
```js
getSporeScript(config, 'Spore', ['v2'])
getSporeScript(config, 'Spore', ['preview'])
getSporeScript(config, 'Spore', ['v2', 'preview'])
```

### SporeScript behavior control

Added a `behaviors` field to the SporeScript:
```js
{
  tags: [ ... ],
  script: { ... },
  cellDep: { ... },
  behaviors: {
    lockProxy: true,
    cobuild: true,
  },
}
```

This feature enables the enablement or disablement of specific functionalities in scripts.

With the behavior control feature, we can easily set `lockProxy: false` for Cluster V1. In such cases, when a Cluster V1 is referenced in a transaction using the lock proxy method, the transaction construction will be terminated.

## Related issues
- resolves #53
- resolves #39 
- resolves #65 