### PR TITLE
bump(sdk): 0.2.0-beta.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -9,10 +9,13 @@
     "eleven-dots-own",
     "itchy-plants-kick",
     "kind-donkeys-lick",
+    "nine-bottles-report",
     "old-oranges-invite",
     "polite-donuts-begin",
+    "slow-tools-flow",
     "small-lobsters-jam",
     "stale-ghosts-lie",
-    "three-cows-unite"
+    "three-cows-unite",
+    "twenty-planets-rest"
   ]
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @spore-sdk/core
 
+## 0.2.0-beta.0
+
+### Minor Changes
+
+- b89681c: Support basic Cobuild feature with legacy locks
+
+### Patch Changes
+
+- 68e7ed8: Support finding SporeScripts by predefined tags
+- aa1895f: Remove minPayment prop from the transferClusterProxy API
+
 ## 0.1.1-beta.0
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spore-sdk/core",
-  "version": "0.1.1-beta.0",
+  "version": "0.2.0-beta.0",
   "license": "MIT",
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
## Include changes
- #68 
- #69 