### PR TITLE
ref(sdk)!: replace v2 preview contracts and bump deps

### DIFF
--- a/.changeset/itchy-goats-beam.md
+++ b/.changeset/itchy-goats-beam.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+BREAKING CHANGE: Replaced v2 previe contracts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
+      - name: Install dependencies
+        run: pnpm i
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,13 +17,13 @@
     "lib"
   ],
   "dependencies": {
-    "@ckb-lumos/bi": "^0.22.0-next.2",
-    "@ckb-lumos/rpc": "^0.22.0-next.2",
-    "@ckb-lumos/base": "^0.22.0-next.2",
-    "@ckb-lumos/lumos": "^0.22.0-next.2",
-    "@ckb-lumos/codec": "^0.22.0-next.2",
-    "@ckb-lumos/config-manager": "^0.22.0-next.2",
-    "@ckb-lumos/common-scripts": "^0.22.0-next.2",
+    "@ckb-lumos/bi": "^0.22.0-next.3",
+    "@ckb-lumos/rpc": "^0.22.0-next.3",
+    "@ckb-lumos/base": "^0.22.0-next.3",
+    "@ckb-lumos/lumos": "^0.22.0-next.3",
+    "@ckb-lumos/codec": "^0.22.0-next.3",
+    "@ckb-lumos/config-manager": "^0.22.0-next.3",
+    "@ckb-lumos/common-scripts": "^0.22.0-next.3",
     "@exact-realty/multipart-parser": "^1.0.9",
     "lodash": "^4.17.21"
   },

--- a/packages/core/src/config/predefined.ts
+++ b/packages/core/src/config/predefined.ts
@@ -15,12 +15,12 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
         {
           tags: ['v2', 'preview'],
           script: {
-            codeHash: '0xfd2dc714c4d4cb81e8621e5c124465a048d06551b467f58eaa64041dd322cf81',
+            codeHash: '0xa32df38d2de1da82cbcb9e4467f8c18479596394eea977e471b75be5fe3e9c67',
             hashType: 'data1',
           },
           cellDep: {
             outPoint: {
-              txHash: '0x4d75c3201b06d9d4e4058468abb2b5d9aebacd4b065f6a855b4cbc2f23dfb87f',
+              txHash: '0xfad85d02822b7ee7c0fe9879c03fcaff695aa7ff2b7a7b740966bf49f47c29c1',
               index: '0x0',
             },
             depType: 'code',
@@ -51,12 +51,12 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
         {
           tags: ['v2', 'preview'],
           script: {
-            codeHash: '0x372b7c11d7b688e02d9c2b7604fbdf0dc898a0f6741854ea6c65d41f8ef4a64e',
+            codeHash: '0x5203a3baf931c15a809c4a0bb7041aebb73118281e31e8d104d926b8523977b1',
             hashType: 'data1',
           },
           cellDep: {
             outPoint: {
-              txHash: '0x4072aa8ef8794cc8e70ae57c1dd29d2a343bc7f0cd6b13ce30ae6cd7d5b6a7d9',
+              txHash: '0xa23dbb38208fd50ce99404780a769784c77bd95a32e0af72c3a87de85d0bf1ba',
               index: '0x0',
             },
             depType: 'code',
@@ -87,12 +87,12 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
         {
           tags: ['v2', 'preview'],
           script: {
-            codeHash: '0xfc1fbe95e7fb5be520f1adb2bdbd1529422613b02254ff01fd0f30604861ae36',
+            codeHash: '0x08e5cecab2bbdea9139534a822d46b82929e06f12f00c68343a88a58827cd3db',
             hashType: 'data1',
           },
           cellDep: {
             outPoint: {
-              txHash: '0xbb0960de5c1960b57babd4cf4f468ac27572d24ef51dba8a2719f31dcebbc88f',
+              txHash: '0x4ca4dcba0f907f054ceace6061f6a143aeea80107eb48fa296d27af63a1714ea',
               index: '0x0',
             },
             depType: 'code',
@@ -109,12 +109,12 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
         {
           tags: ['v2', 'preview'],
           script: {
-            codeHash: '0xa170fc93235213e90214e4273bb283e7979bf6477f70b4f2319d3777ec36235c',
+            codeHash: '0x88850ac632eed604f0ad784394004db384d0eea8038a24eee83439687d79343f',
             hashType: 'data1',
           },
           cellDep: {
             outPoint: {
-              txHash: '0x4951fba8ae56d10c409221e412b5b5457da8b23e92b1fab8c627f609a4f53929',
+              txHash: '0xde33357919460d527abf53ff61881e62e0b3afc5f4fb95b34783b5827e59d82d',
               index: '0x0',
             },
             depType: 'code',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,26 +81,26 @@ importers:
   packages/core:
     dependencies:
       '@ckb-lumos/base':
-        specifier: ^0.22.0-next.2
-        version: 0.22.0-next.2
+        specifier: ^0.22.0-next.3
+        version: 0.22.0-next.3
       '@ckb-lumos/bi':
-        specifier: ^0.22.0-next.2
-        version: 0.22.0-next.2
+        specifier: ^0.22.0-next.3
+        version: 0.22.0-next.3
       '@ckb-lumos/codec':
-        specifier: ^0.22.0-next.2
-        version: 0.22.0-next.2
+        specifier: ^0.22.0-next.3
+        version: 0.22.0-next.3
       '@ckb-lumos/common-scripts':
-        specifier: ^0.22.0-next.2
-        version: 0.22.0-next.2
+        specifier: ^0.22.0-next.3
+        version: 0.22.0-next.3
       '@ckb-lumos/config-manager':
-        specifier: ^0.22.0-next.2
-        version: 0.22.0-next.2
+        specifier: ^0.22.0-next.3
+        version: 0.22.0-next.3
       '@ckb-lumos/lumos':
-        specifier: ^0.22.0-next.2
-        version: 0.22.0-next.2
+        specifier: ^0.22.0-next.3
+        version: 0.22.0-next.3
       '@ckb-lumos/rpc':
-        specifier: ^0.22.0-next.2
-        version: 0.22.0-next.2
+        specifier: ^0.22.0-next.3
+        version: 0.22.0-next.3
       '@exact-realty/multipart-parser':
         specifier: ^1.0.9
         version: 1.0.9
@@ -326,13 +326,13 @@ packages:
       prettier: 2.8.7
     dev: true
 
-  /@ckb-lumos/base@0.22.0-next.2:
-    resolution: {integrity: sha512-41oCLYF854p38hLJ1CzWfaD8JywJGxgGQ8xuC9HNeChajZYI1DXWayFE41emF7FlXyI+ItwxMihcvUEEOBX/lg==}
+  /@ckb-lumos/base@0.22.0-next.3:
+    resolution: {integrity: sha512-lHu7XLEVPAuRKmrsjrSy8iedN/LrZ7rP8ZvbkcWO8NS07bXdzrRAs/GIx1Ml9xGKpv6akLGVek3oXhQGggnj/w==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       '@types/blake2b': 2.1.0
       '@types/lodash.isequal': 4.5.6
       blake2b: 2.1.4
@@ -340,68 +340,71 @@ packages:
       lodash.isequal: 4.5.0
     dev: false
 
-  /@ckb-lumos/bi@0.22.0-next.2:
-    resolution: {integrity: sha512-lbpAFPg2ihL0qPJm+gbR9R1tt421xjXIBnQ84YIYilb+hkclDYbd/J5EeA1yag/ggh5tqf5996/CpchG9BhXiQ==}
+  /@ckb-lumos/bi@0.22.0-next.3:
+    resolution: {integrity: sha512-4vA3512b6QLkoqZxVhbB6Z1LuqbXNkQwlVIWJXzSZQsYCt7iq8TgkSc9mPRYm17SXIp5BnsC5HN/qtlxHSfv1g==}
     engines: {node: '>=12.0.0'}
     dependencies:
       jsbi: 4.3.0
     dev: false
 
-  /@ckb-lumos/ckb-indexer@0.22.0-next.2:
-    resolution: {integrity: sha512-Go4XuqgRo/G74hc9QOlBQhy0VGDJqFJ87NpRIBhGZgj82nPOXqEp+BZWG6wO/Vs4u7tPhuVicRDuIrCIG6DmxQ==}
+  /@ckb-lumos/ckb-indexer@0.22.0-next.3:
+    resolution: {integrity: sha512-Y6LzyGW1ItQ1RDSIcGbqiIVVSaVpF2LH8eOI3o4sDY35jB/AfLN51Dy3AfHeeAXbHM29mRxOGSCssK24O+Xy5A==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       cross-fetch: 3.1.8
       events: 3.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/codec@0.22.0-next.2:
-    resolution: {integrity: sha512-uBcMUDr7phIYhiP3yetee2IlChVPGdFHLYf+KlIN3Xsvw4ihs3t2/b0wJ3Aj4eCk03Zb/vyIBuGsGtx1phJrXA==}
+  /@ckb-lumos/codec@0.22.0-next.3:
+    resolution: {integrity: sha512-VBmb4vQ/iXTG/J0vi5f61ekpadX1XlJEF5NubtiJtAsaCFHjFkExS8PHxePEVIJVxy5YqZu0/AcZXnHDl9P40w==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.3
     dev: false
 
-  /@ckb-lumos/common-scripts@0.22.0-next.2:
-    resolution: {integrity: sha512-zAqjreoWtJuGv+IucuJVh0fNsfWoXVCqUh3JBPMcKdGpqN02ZpTB2Dd1KGqC7ec/usky6HDTh0uoZEqFdCsC0Q==}
+  /@ckb-lumos/common-scripts@0.22.0-next.3:
+    resolution: {integrity: sha512-i7eXxgGJE5a9uhKmehNrQAfPhvMW0lA5yCfFxY0fpLMeymj9bFGVUXiEk/8XLpMZgwIRFRYOSEbXXkw3tE8HUA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/config-manager': 0.22.0-next.2
-      '@ckb-lumos/helpers': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/config-manager': 0.22.0-next.3
+      '@ckb-lumos/helpers': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       immutable: 4.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/config-manager@0.22.0-next.2:
-    resolution: {integrity: sha512-qwgbDEkgaqweQ87MvSk//Es88xLhAGgtrc5E0nAPFTUI9oDwZ1w4VeitIIaXg0K44dnYYI4511zcYbu39SR3kg==}
+  /@ckb-lumos/config-manager@0.22.0-next.3:
+    resolution: {integrity: sha512-fkW20X17oCik9PZ8cxZNh4SIubkVtU4KR6LO7solUZ2mgrTQVDW6U8+wynkFSUvKyr05lEWa74tsVZtlW6x24A==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
       '@types/deep-freeze-strict': 1.1.0
       deep-freeze-strict: 1.1.1
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
-  /@ckb-lumos/hd@0.22.0-next.2:
-    resolution: {integrity: sha512-4qazlWkBfE1pb0F9TFptKL7fWA7NULHauTWrJ7v5qZphBVtj9XtL7uasQ0vqdAWzmIWmnkA9tUYdWcye1ujk6Q==}
+  /@ckb-lumos/hd@0.22.0-next.3:
+    resolution: {integrity: sha512-zxL1LqiYJuGuwWvfe7e2qgih56dRogfvnFaJLkUKG6riDm7jhBm0bzS+FlIpEMI+RkY/XPbUcvf4cSocjtRxfg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
       bn.js: 5.2.1
       elliptic: 6.5.4
       scrypt-js: 3.0.1
@@ -409,80 +412,82 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@ckb-lumos/helpers@0.22.0-next.2:
-    resolution: {integrity: sha512-VIoyJyF0fu2ts4Yp03CZZ5ALuNme7ZE2CA7d5SFsZH8bUFCkHbm6aWfCHiV2L9fW+t4uJZGrLYDOjxYLmoy6Lg==}
+  /@ckb-lumos/helpers@0.22.0-next.3:
+    resolution: {integrity: sha512-qJPVDjcIFGwLKOPA9Xvwu5wcGrh9nlXhYCjnlHbTYO6uWRnIltBusCIBn0PapmwxbgLb2qagkCmMfbgwyZ4gfQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/config-manager': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/config-manager': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       bech32: 2.0.0
       immutable: 4.3.0
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
-  /@ckb-lumos/light-client@0.22.0-next.2:
-    resolution: {integrity: sha512-hFIs0E0ratMvoBRTWTQOaWh2Qsai+MmdQYXkMnuPdLTEYlKckHS5VnHVpLqYu8acnmlaTwjuF85ojZNUxM1WXQ==}
+  /@ckb-lumos/light-client@0.22.0-next.3:
+    resolution: {integrity: sha512-KjrlwrsuTALPJ/P3lRA661MPpEJMsszH46lkS5pkdJ4+5x6UNf9SuUqA/N8dtpcnPZq6dUVJiN0wd3yqroHygw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
       cross-fetch: 3.1.8
       events: 3.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/lumos@0.22.0-next.2:
-    resolution: {integrity: sha512-aabZBF+B+F3Dyr2EW7xqWppmQNQYyMX4BdSrwGtOwDllby0/kM5f09CxyMf4Uk6En3rzMrh3z1SOQ94OVTzAQA==}
+  /@ckb-lumos/lumos@0.22.0-next.3:
+    resolution: {integrity: sha512-wagcumbQCPHTkCINy6D73PY2s9bESijvuxfj4AB3cLCiOEdg+SgpQuMhiaDx96H4pkFeeRKF0beljfVtI0+i9Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/common-scripts': 0.22.0-next.2
-      '@ckb-lumos/config-manager': 0.22.0-next.2
-      '@ckb-lumos/hd': 0.22.0-next.2
-      '@ckb-lumos/helpers': 0.22.0-next.2
-      '@ckb-lumos/light-client': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
-      '@ckb-lumos/transaction-manager': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/common-scripts': 0.22.0-next.3
+      '@ckb-lumos/config-manager': 0.22.0-next.3
+      '@ckb-lumos/hd': 0.22.0-next.3
+      '@ckb-lumos/helpers': 0.22.0-next.3
+      '@ckb-lumos/light-client': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
+      '@ckb-lumos/transaction-manager': 0.22.0-next.3
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/rpc@0.22.0-next.2:
-    resolution: {integrity: sha512-V87fniKRI81XNIwesD9PIatj5D0WWUZYXnEjYFntnTXZ/w95B/uUIz2SqievU8oIMbFAMIzDIcVdpOcMMoZ9Aw==}
+  /@ckb-lumos/rpc@0.22.0-next.3:
+    resolution: {integrity: sha512-50ej2nBkHQgV5gcvkJv6Pa61vTXuiQxPcg3tr/lY7OUQ3dta1O3VkIADfP2k7P9busv9SVeffxQuEauUORP+eg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
       abort-controller: 3.0.0
       cross-fetch: 3.1.8
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/toolkit@0.22.0-next.2:
-    resolution: {integrity: sha512-HHYRp0QwTSZHkzBGb3JAeDgOAPugibR5DnSrEAlq93RDBCX3Oy7WrE3R9BI3P6TmH5RAs0KKpMcVwVc9J1FJcQ==}
+  /@ckb-lumos/toolkit@0.22.0-next.3:
+    resolution: {integrity: sha512-+3nVXcH6P1G18h+kMmSKShcBWNwiPJZ6OUqit15uhFQxu/TAiUSk9C/xHAGUpQCXBIoIWvVXDMZThYCyx3yk8Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.3
     dev: false
 
-  /@ckb-lumos/transaction-manager@0.22.0-next.2:
-    resolution: {integrity: sha512-Wre1zWJDIDZxZz5eFosVcU+zodYSH3TrANCwldWxIXshZcHKyePkPf0SO9wcUas3pXHXtCqO/xe7FEfhLJj6Eg==}
+  /@ckb-lumos/transaction-manager@0.22.0-next.3:
+    resolution: {integrity: sha512-yUNo3t6qnSWNoL7M729YAVn8JjpF97r3PeS4j1chdTB+Cu+zVqyiLtQRyGZ9VFdFs56HmRt4pmEwuLKEkIIGOg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       immutable: 4.3.0
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
## Changes
- BREAKING CHANGE: Replaced v2 preview contracts
- Upgraded lumos to o.22.0-beta.3
- Fixed an issue in the release ci

## V2 preview contracts

Ran testnet/devnet tests in my local environment, all passed except the -1 error when referencing a Cluster V1.