### PR TITLE
chore(ci): add contents write permission to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Our previous [release workflow](https://github.com/sporeprotocol/spore-sdk/actions/runs/7579003744) for the 0.2.0-beta.1 version has failed:
- The npm publishing succeeded, no issue on this side
- The github releasing failed, because it enountered a permission issue

After conducting some research, I think adding a `contents: write` permission for the workflow should resolve the issue.
Refer to the github docs for more info: [Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).