### PR TITLE
ref(sdk)!: replace v2 contracts with v1-compatible version

### DIFF
--- a/.changeset/strange-forks-brake.md
+++ b/.changeset/strange-forks-brake.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+BREAKING CHANGE: Replaced v2 contracts with a v1-compatible preview version

--- a/.changeset/thirty-bugs-applaud.md
+++ b/.changeset/thirty-bugs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Support selecting v1/v2 version when creating clusters

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,4 +79,5 @@ jobs:
         env:
           VITE_ACCOUNT_CHARLIE: ${{ secrets.ACCOUNT_CHARLIE }}
           VITE_ACCOUNT_ALICE: ${{ secrets.ACCOUNT_ALICE }}
+          VITE_TEST_CLUSTER_V1: true
           VITE_NETWORK: devnet

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,13 +17,13 @@
     "lib"
   ],
   "dependencies": {
-    "@ckb-lumos/bi": "^0.22.0-next.3",
-    "@ckb-lumos/rpc": "^0.22.0-next.3",
-    "@ckb-lumos/base": "^0.22.0-next.3",
-    "@ckb-lumos/lumos": "^0.22.0-next.3",
-    "@ckb-lumos/codec": "^0.22.0-next.3",
-    "@ckb-lumos/config-manager": "^0.22.0-next.3",
-    "@ckb-lumos/common-scripts": "^0.22.0-next.3",
+    "@ckb-lumos/bi": "^0.22.0-next.4",
+    "@ckb-lumos/rpc": "^0.22.0-next.4",
+    "@ckb-lumos/base": "^0.22.0-next.4",
+    "@ckb-lumos/lumos": "^0.22.0-next.4",
+    "@ckb-lumos/codec": "^0.22.0-next.4",
+    "@ckb-lumos/config-manager": "^0.22.0-next.4",
+    "@ckb-lumos/common-scripts": "^0.22.0-next.4",
     "@exact-realty/multipart-parser": "^1.0.9",
     "lodash": "^4.17.21"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "vitest": "^1.1.0"
+    "vitest": "^1.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/__tests__/Cluster.test.ts
+++ b/packages/core/src/__tests__/Cluster.test.ts
@@ -9,14 +9,14 @@ import { createCluster, createSpore, getClusterById, getClusterByOutPoint, trans
 import {
   TEST_ENV,
   TEST_ACCOUNTS,
+  TEST_VARIABLES,
   SPORE_OUTPOINT_RECORDS,
   CLUSTER_OUTPOINT_RECORDS,
-  TEST_VARIABLES,
   cleanupRecords,
 } from './shared';
 
 describe('Cluster', () => {
-  const { rpc, config } = TEST_ENV;
+  const { rpc, config, v1Config } = TEST_ENV;
   const { CHARLIE, ALICE } = TEST_ACCOUNTS;
 
   let existingClusterRecord: OutPointRecord | undefined;
@@ -226,60 +226,112 @@ describe('Cluster', () => {
   });
 
   describe.runIf(TEST_VARIABLES.tests.clusterV1)('Spore with Cluster (v1)', () => {
+    let clusterV1OutPointRecord: OutPointRecord | undefined;
     const clusterV1IdRecord: IdRecord = {
       id: '0x8b9f893397310a3bbd925cd1c9ab606555675bb2d03f3c5cb934f2ba4ef97e93',
       account: CHARLIE,
     };
+
+    async function getClusterV1Record() {
+      if (TEST_VARIABLES.network === 'devnet') {
+        expect(clusterV1OutPointRecord).toBeDefined();
+        return {
+          cell: await getClusterByOutPoint(clusterV1OutPointRecord!.outPoint, config),
+          account: clusterV1OutPointRecord!.account,
+        };
+      } else {
+        expect(clusterV1IdRecord).toBeDefined();
+        const cell = await getClusterById(clusterV1IdRecord.id, config);
+        return {
+          cell: await getClusterByOutPoint(cell.outPoint!, config),
+          account: clusterV1IdRecord.account,
+        };
+      }
+    }
+
+    it.runIf(TEST_VARIABLES.network === 'devnet')(
+      'Create a Cluster (v1) if necessary',
+      async () => {
+        const { txSkeleton, outputIndex } = await createCluster({
+          data: {
+            name: 'Testnet Spores',
+            description: 'Testing only',
+          },
+          fromInfos: [CHARLIE.address],
+          toLock: CHARLIE.lock,
+          config: v1Config,
+        });
+
+        const clusterOutput = getClusterOutput(txSkeleton, outputIndex, v1Config);
+        const clusterScript = clusterOutput.script;
+
+        expect(clusterScript).toHaveProperty('tags');
+        expect(clusterScript.tags).toContain('v1');
+
+        const hash = await signAndSendTransaction({
+          account: CHARLIE,
+          txSkeleton,
+          rpc,
+          send: true,
+          config: v1Config,
+        });
+        if (hash) {
+          clusterV1OutPointRecord = {
+            outPoint: {
+              txHash: hash,
+              index: BI.from(outputIndex).toHexString(),
+            },
+            account: CHARLIE,
+          };
+        }
+      },
+      0,
+    );
     it('Create a Spore with Cluster (via lock proxy)', async () => {
-      expect(clusterV1IdRecord).toBeDefined();
-      const clusterRecord = clusterV1IdRecord;
-      const clusterCell = await retryQuery(async () => {
-        const cell = await getClusterById(clusterRecord.id, config);
-        return await getClusterByOutPoint(cell.outPoint!, config);
-      });
+      const { cell: clusterCell, account: recordAccount } = await retryQuery(getClusterV1Record);
 
       expectCellLock(clusterCell, [CHARLIE.lock, ALICE.lock]);
+      const clusterId = clusterCell.cellOutput.type!.args;
 
       await expect(() =>
         createSpore({
           data: {
-            clusterId: clusterRecord.id,
+            clusterId: clusterId,
             contentType: 'text/plain',
             content: bytifyRawString('content'),
           },
-          toLock: clusterRecord.account.lock,
-          fromInfos: [clusterRecord.account.address],
+          toLock: recordAccount.lock,
+          fromInfos: [recordAccount.address],
           config,
         }),
       ).rejects.toThrowError('Cannot reference Cluster because target Cluster does not supported lockProxy');
     }, 0);
     it('Create a Spore with Cluster (via cell reference)', async () => {
-      expect(clusterV1IdRecord).toBeDefined();
-      const clusterRecord = clusterV1IdRecord;
-      const clusterCell = await retryQuery(async () => {
-        const cell = await getClusterById(clusterRecord.id, config);
-        return await getClusterByOutPoint(cell.outPoint!, config);
-      });
+      const { cell: clusterCell, account: recordAccount } = await retryQuery(getClusterV1Record);
 
       expectCellLock(clusterCell, [CHARLIE.lock, ALICE.lock]);
-      const oppositeAccount = clusterRecord.account.address === ALICE.address ? CHARLIE : ALICE;
 
-      // TODO: Wait for 1 block time to prevent double-spend, should resolve issue#25
-      await waitForMilliseconds(20000);
+      const clusterId = clusterCell.cellOutput.type!.args;
+      const oppositeAccount = recordAccount.address === ALICE.address ? CHARLIE : ALICE;
+
+      if (TEST_VARIABLES.network !== 'devnet') {
+        // TODO: Wait for some block times to prevent double-spend, should resolve issue#25
+        await waitForMilliseconds(20000);
+      }
 
       const { txSkeleton, outputIndex, reference } = await createSpore({
         data: {
-          clusterId: clusterRecord.id,
+          clusterId: clusterId,
           contentType: 'text/plain',
           content: bytifyRawString('content'),
         },
-        toLock: clusterRecord.account.lock,
+        toLock: recordAccount.lock,
         fromInfos: [oppositeAccount.address],
         config,
       });
 
       const spore = getSporeOutput(txSkeleton, outputIndex, config);
-      expect(spore.data.clusterId).toEqual(clusterRecord.id);
+      expect(spore.data.clusterId).toEqual(clusterId);
 
       expect(reference).toBeDefined();
       expect(reference.referenceTarget).toEqual('cluster');
@@ -291,7 +343,7 @@ describe('Cluster', () => {
 
       const cluster = getClusterOutput(txSkeleton, reference.cluster!.outputIndex, config);
       expectTypeCell(txSkeleton, 'both', cluster.cell.cellOutput.type!);
-      expect(cluster.id).toEqual(clusterRecord.id);
+      expect(cluster.id).toEqual(clusterId);
 
       const clusterScript = getSporeScript(config, 'Cluster', cluster.cell.cellOutput.type!);
       expectCellDep(txSkeleton, clusterScript.cellDep);
@@ -301,19 +353,26 @@ describe('Cluster', () => {
       });
 
       const hash = await signAndSendTransaction({
-        account: [oppositeAccount, clusterRecord.account],
+        account: [oppositeAccount, recordAccount],
         txSkeleton,
         config,
         rpc,
         send: true,
       });
       if (hash) {
+        clusterV1OutPointRecord = {
+          outPoint: {
+            txHash: hash,
+            index: BI.from(reference.cluster!.outputIndex).toHexString(),
+          },
+          account: recordAccount,
+        };
         SPORE_OUTPOINT_RECORDS.push({
           outPoint: {
             txHash: hash,
             index: BI.from(outputIndex).toHexString(),
           },
-          account: clusterRecord.account,
+          account: recordAccount,
         });
       }
     }, 0);

--- a/packages/core/src/__tests__/Cluster.test.ts
+++ b/packages/core/src/__tests__/Cluster.test.ts
@@ -252,6 +252,9 @@ describe('Cluster', () => {
     it.runIf(TEST_VARIABLES.network === 'devnet')(
       'Create a Cluster (v1) if necessary',
       async () => {
+        // Wait some time for the indexer to be updated
+        await waitForMilliseconds(1500);
+
         const { txSkeleton, outputIndex } = await createCluster({
           data: {
             name: 'Testnet Spores',
@@ -275,6 +278,7 @@ describe('Cluster', () => {
           send: true,
           config: v1Config,
         });
+
         if (hash) {
           clusterV1OutPointRecord = {
             outPoint: {

--- a/packages/core/src/__tests__/ClusterProxyAgent.test.ts
+++ b/packages/core/src/__tests__/ClusterProxyAgent.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, it } from 'vitest';
 import { BI, utils } from '@ckb-lumos/lumos';
 import { getSporeScript } from '../config';
-import { bytifyRawString, minimalCellCapacityByLock } from '../helpers';
+import { bytifyRawString, minimalCellCapacityByLock, waitForMilliseconds } from '../helpers';
 import { packRawClusterAgentDataToHash, unpackToRawClusterProxyArgs } from '../codec';
 import { createSpore, createCluster, getClusterByOutPoint, getClusterById } from '../api';
 import { createClusterProxy, transferClusterProxy, meltClusterProxy, getClusterProxyByOutPoint } from '../api';
@@ -626,6 +626,9 @@ describe('ClusterProxy and ClusterAgent', () => {
     it.runIf(TEST_VARIABLES.network === 'devnet')(
       'Create a Cluster (v1) if necessary',
       async () => {
+        // Wait some time for the indexer to be updated
+        await waitForMilliseconds(1500);
+
         const { txSkeleton, outputIndex } = await createCluster({
           data: {
             name: 'Testnet Spores',
@@ -666,7 +669,7 @@ describe('ClusterProxy and ClusterAgent', () => {
 
       expectCellLock(clusterCell, [CHARLIE.lock, ALICE.lock]);
 
-      expect(() =>
+      await expect(() =>
         createClusterProxy({
           clusterOutPoint: clusterCell.outPoint!,
           minPayment: 10,

--- a/packages/core/src/__tests__/ClusterProxyAgent.test.ts
+++ b/packages/core/src/__tests__/ClusterProxyAgent.test.ts
@@ -2,19 +2,15 @@ import { afterAll, describe, expect, it } from 'vitest';
 import { BI, utils } from '@ckb-lumos/lumos';
 import { getSporeScript } from '../config';
 import { bytifyRawString, minimalCellCapacityByLock } from '../helpers';
-import { createSpore, createCluster, getClusterByOutPoint, getClusterById } from '../api';
 import { packRawClusterAgentDataToHash, unpackToRawClusterProxyArgs } from '../codec';
+import { createSpore, createCluster, getClusterByOutPoint, getClusterById } from '../api';
 import { createClusterProxy, transferClusterProxy, meltClusterProxy, getClusterProxyByOutPoint } from '../api';
 import { createClusterAgent, transferClusterAgent, meltClusterAgent, getClusterAgentByOutPoint } from '../api';
-import {
-  getClusterAgentOutput,
-  getSporeOutput,
-  getClusterProxyOutput,
-  IdRecord,
-  getActionsFromCobuildWitnessLayout,
-} from './helpers';
-import { signAndSendTransaction, retryQuery, popRecord, OutPointRecord } from './helpers';
 import { expectCellDep, expectLockCell, expectTypeCell, expectTypeId, expectCellLock } from './helpers';
+import { getClusterAgentOutput, getSporeOutput, getClusterProxyOutput, IdRecord } from './helpers';
+import { signAndSendTransaction, retryQuery, popRecord, OutPointRecord } from './helpers';
+import { getClusterOutput, getActionsFromCobuildWitnessLayout } from './helpers';
+import { createSporeScriptInfoFromTemplate, ScriptInfo } from '../cobuild';
 import {
   TEST_ENV,
   TEST_ACCOUNTS,
@@ -25,10 +21,9 @@ import {
   CLUSTER_AGENT_OUTPOINT_RECORDS,
   cleanupRecords,
 } from './shared';
-import { createSporeScriptInfoFromTemplate, ScriptInfo } from '../cobuild';
 
 describe('ClusterProxy and ClusterAgent', () => {
-  const { rpc, config } = TEST_ENV;
+  const { rpc, config, v1Config } = TEST_ENV;
   const { CHARLIE, ALICE } = TEST_ACCOUNTS;
 
   let existingClusterRecord: OutPointRecord | undefined;
@@ -605,33 +600,102 @@ describe('ClusterProxy and ClusterAgent', () => {
   });
 
   describe.runIf(TEST_VARIABLES.tests.clusterV1)('ClusterAgent with Cluster (v1)', () => {
+    let clusterV1OutPointRecord: OutPointRecord | undefined;
     const clusterV1IdRecord: IdRecord = {
       id: '0x8b9f893397310a3bbd925cd1c9ab606555675bb2d03f3c5cb934f2ba4ef97e93',
       account: CHARLIE,
     };
-    it('Create a ClusterProxy with Cluster (via cell reference)', async () => {
-      expect(clusterV1IdRecord).toBeDefined();
-      const clusterRecord = clusterV1IdRecord;
-      const clusterCell = await retryQuery(async () => {
-        const cell = await getClusterById(clusterRecord.id, config);
-        return await getClusterByOutPoint(cell.outPoint!, config);
-      });
+
+    async function getClusterV1Record() {
+      if (TEST_VARIABLES.network === 'devnet') {
+        expect(clusterV1OutPointRecord).toBeDefined();
+        return {
+          cell: await getClusterByOutPoint(clusterV1OutPointRecord!.outPoint, config),
+          account: clusterV1OutPointRecord!.account,
+        };
+      } else {
+        expect(clusterV1IdRecord).toBeDefined();
+        const cell = await getClusterById(clusterV1IdRecord.id, config);
+        return {
+          cell: await getClusterByOutPoint(cell.outPoint!, config),
+          account: clusterV1IdRecord.account,
+        };
+      }
+    }
+
+    it.runIf(TEST_VARIABLES.network === 'devnet')(
+      'Create a Cluster (v1) if necessary',
+      async () => {
+        const { txSkeleton, outputIndex } = await createCluster({
+          data: {
+            name: 'Testnet Spores',
+            description: 'Testing only',
+          },
+          fromInfos: [CHARLIE.address],
+          toLock: CHARLIE.lock,
+          config: v1Config,
+        });
+
+        const clusterOutput = getClusterOutput(txSkeleton, outputIndex, v1Config);
+        const clusterScript = clusterOutput.script;
+
+        expect(clusterScript).toHaveProperty('tags');
+        expect(clusterScript.tags).toContain('v1');
+
+        const hash = await signAndSendTransaction({
+          account: CHARLIE,
+          txSkeleton,
+          rpc,
+          send: true,
+          config: v1Config,
+        });
+        if (hash) {
+          clusterV1OutPointRecord = {
+            outPoint: {
+              txHash: hash,
+              index: BI.from(outputIndex).toHexString(),
+            },
+            account: CHARLIE,
+          };
+        }
+      },
+      0,
+    );
+    it('Create a ClusterProxy with Cluster (via lock proxy)', async () => {
+      const { cell: clusterCell, account: recordAccount } = await retryQuery(getClusterV1Record);
 
       expectCellLock(clusterCell, [CHARLIE.lock, ALICE.lock]);
-      const oppositeAccount = clusterRecord.account.address === CHARLIE.address ? ALICE : CHARLIE;
+
+      expect(() =>
+        createClusterProxy({
+          clusterOutPoint: clusterCell.outPoint!,
+          minPayment: 10,
+          toLock: recordAccount.lock,
+          fromInfos: [recordAccount.address],
+          config,
+        }),
+      ).rejects.toThrowError('Cannot reference Cluster because target Cluster does not supported lockProxy');
+    }, 0);
+    it('Create a ClusterProxy with Cluster (via cell reference)', async () => {
+      const { cell: clusterCell, account: recordAccount } = await retryQuery(getClusterV1Record);
+
+      expectCellLock(clusterCell, [CHARLIE.lock, ALICE.lock]);
+      const oppositeAccount = recordAccount.address === CHARLIE.address ? ALICE : CHARLIE;
+
+      const clusterId = clusterCell.cellOutput.type!.args;
 
       const { txSkeleton, outputIndex, reference } = await createClusterProxy({
         clusterOutPoint: clusterCell.outPoint!,
         minPayment: 10,
-        toLock: clusterRecord.account.lock,
+        toLock: recordAccount.lock,
         fromInfos: [oppositeAccount.address],
         config,
       });
 
       const clusterProxy = getClusterProxyOutput(txSkeleton, outputIndex, config);
-      expect(clusterProxy.cell.cellOutput.lock).toEqual(clusterRecord.account.lock);
+      expect(clusterProxy.cell.cellOutput.lock).toEqual(recordAccount.lock);
       expectTypeId(txSkeleton, outputIndex, clusterProxy.id);
-      expect(clusterProxy.data).toEqual(clusterRecord.id);
+      expect(clusterProxy.data).toEqual(clusterId);
       expect(clusterProxy.args.minPayment).toBeDefined();
       expect(clusterProxy.args.minPayment!.toNumber()).toEqual(10);
 
@@ -654,27 +718,33 @@ describe('ClusterProxy and ClusterAgent', () => {
       });
 
       const hash = await signAndSendTransaction({
-        account: [clusterRecord.account, oppositeAccount],
+        account: [recordAccount, oppositeAccount],
         txSkeleton,
         config,
         rpc,
         send: true,
       });
       if (hash) {
-        existingClusterRecord = void 0;
+        clusterV1OutPointRecord = {
+          outPoint: {
+            txHash: hash,
+            index: BI.from(reference.cluster!.outputIndex).toHexString(),
+          },
+          account: recordAccount,
+        };
         CLUSTER_OUTPOINT_RECORDS.push({
           outPoint: {
             txHash: hash,
             index: BI.from(reference.cluster!.outputIndex).toHexString(),
           },
-          account: clusterRecord.account,
+          account: recordAccount,
         });
         CLUSTER_PROXY_OUTPOINT_RECORDS.push({
           outPoint: {
             txHash: hash,
             index: BI.from(outputIndex).toHexString(),
           },
-          account: clusterRecord.account,
+          account: recordAccount,
         });
       }
     }, 0);

--- a/packages/core/src/__tests__/Codec.test.ts
+++ b/packages/core/src/__tests__/Codec.test.ts
@@ -139,18 +139,30 @@ describe('Codec', function () {
         '0x3a0000000c0000001c0000000c000000636c7573746572206e616d651a0000006465736372697074696f6e206f662074686520636c7573746572',
     },
   ];
-  it('Unpack ClusterData', function () {
+  it('Pack ClusterDataV1', function () {
+    for (let i = 0; i < clusterDataV1Tests.length; i++) {
+      const test = clusterDataV1Tests[i];
+      const packed = packRawClusterData(test.packable, 'v1');
+      const packedHex = bytes.hexify(packed);
+      expect(packedHex).eq(test.packed, `ClusterDataV1 in test #${i} should be packable`);
+    }
+  });
+  it('Unpack ClusterDataV1', function () {
     for (let i = 0; i < clusterDataV1Tests.length; i++) {
       const test = clusterDataV1Tests[i];
       const unpacked = unpackToRawClusterData(test.packed);
+      const unpackedV1 = unpackToRawClusterData(test.packed, 'v1');
+
+      // Cluster unpacked with/without version specified should be the same
+      expect(unpacked).toEqual(unpackedV1);
 
       // ClusterData.name
-      expect(unpacked.name).eq(test.packable.name, `ClusterData.name in test #${i} should be unpackable`);
+      expect(unpacked.name).eq(test.packable.name, `ClusterDataV1.name in test #${i} should be unpackable`);
 
       // ClusterData.description
       expect(unpacked.description).eq(
         test.packable.description,
-        `ClusterData.description in test #${i} should be unpackable`,
+        `ClusterDataV1.description in test #${i} should be unpackable`,
       );
     }
   });

--- a/packages/core/src/__tests__/helpers/config.ts
+++ b/packages/core/src/__tests__/helpers/config.ts
@@ -43,6 +43,20 @@ export function generateDevnetSporeConfig(config: Record<any, any>): SporeConfig
               cobuild: true,
             },
           },
+          {
+            tags: ['v1', 'latest'],
+            script: {
+              codeHash: config.SCRIPTS.SPORE_V1.CODE_HASH,
+              hashType: config.SCRIPTS.SPORE_V1.HASH_TYPE,
+            },
+            cellDep: {
+              outPoint: {
+                txHash: config.SCRIPTS.SPORE_V1.TX_HASH,
+                index: config.SCRIPTS.SPORE_V1.INDEX,
+              },
+              depType: config.SCRIPTS.SPORE_V1.DEP_TYPE,
+            },
+          },
         ],
       },
       Cluster: {
@@ -63,6 +77,23 @@ export function generateDevnetSporeConfig(config: Record<any, any>): SporeConfig
             behaviors: {
               lockProxy: true,
               cobuild: true,
+            },
+          },
+          {
+            tags: ['v1', 'latest'],
+            script: {
+              codeHash: config.SCRIPTS.CLUSTER_V1.CODE_HASH,
+              hashType: config.SCRIPTS.CLUSTER_V1.HASH_TYPE,
+            },
+            cellDep: {
+              outPoint: {
+                txHash: config.SCRIPTS.CLUSTER_V1.TX_HASH,
+                index: config.SCRIPTS.CLUSTER_V1.INDEX,
+              },
+              depType: config.SCRIPTS.CLUSTER_V1.DEP_TYPE,
+            },
+            behaviors: {
+              clusterDataVersion: 'v1',
             },
           },
         ],

--- a/packages/core/src/__tests__/shared/env.ts
+++ b/packages/core/src/__tests__/shared/env.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 import { RPC, Indexer } from '@ckb-lumos/lumos';
 import { getEnvVariable, generateTestConfig, createDefaultLockAccount } from '../helpers';
+import { forkSporeConfig } from '../../config';
 
 export const TEST_VARIABLES = {
   network: getEnvVariable('VITE_NETWORK', 'string', 'testnet'),
@@ -26,6 +27,9 @@ const config = generateTestConfig(TEST_VARIABLES.network, resolve(__dirname, TES
 
 export const TEST_ENV = {
   config,
+  v1Config: forkSporeConfig(config, {
+    defaultTags: ['v1'],
+  }),
   rpc: new RPC(config.ckbNodeUrl),
   indexer: new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl),
 };

--- a/packages/core/src/api/joints/cluster/injectNewClusterOutput.ts
+++ b/packages/core/src/api/joints/cluster/injectNewClusterOutput.ts
@@ -36,6 +36,7 @@ export function injectNewClusterOutput(props: {
 
   // Create Cluster cell (the latest version)
   const clusterScript = getSporeScript(config, 'Cluster');
+  const clusterData = packRawClusterData(props.data, clusterScript.behaviors?.clusterDataVersion as any);
   let clusterCell: Cell = correctCellMinimalCapacity({
     cellOutput: {
       capacity: '0x0',
@@ -45,7 +46,7 @@ export function injectNewClusterOutput(props: {
         args: '0x' + '0'.repeat(64), // Fill 32-byte TypeId placeholder
       },
     },
-    data: bytes.hexify(packRawClusterData(props.data)),
+    data: bytes.hexify(clusterData),
   });
 
   // Add to Transaction.outputs

--- a/packages/core/src/codec/cluster.ts
+++ b/packages/core/src/codec/cluster.ts
@@ -1,5 +1,5 @@
 import { blockchain, Hash } from '@ckb-lumos/base';
-import { BytesLike, molecule } from '@ckb-lumos/codec';
+import { bytes, BytesLike, molecule } from '@ckb-lumos/codec';
 import { bytifyRawString, bufferToRawString } from '../helpers';
 
 export const ClusterDataV2 = molecule.table(
@@ -19,13 +19,43 @@ export const ClusterDataV1 = molecule.table(
   ['name', 'description'],
 );
 
-export interface RawClusterData {
+export interface RawClusterDataV1 {
+  name: string;
+  description: string;
+}
+export interface RawClusterDataV2 {
   name: string;
   description: string;
   mutantId?: Hash;
 }
+export type RawClusterData = RawClusterDataV2;
 
-export function packRawClusterData(packable: RawClusterData): Uint8Array {
+export type ClusterDataVersion = 'v1' | 'v2';
+
+export function packRawClusterData(packable: RawClusterData): Uint8Array;
+export function packRawClusterData(packable: RawClusterDataV1, version: 'v1'): Uint8Array;
+export function packRawClusterData(packable: RawClusterDataV2, version: 'v2'): Uint8Array;
+export function packRawClusterData(packable: RawClusterDataV1 | RawClusterDataV2, version?: unknown): Uint8Array {
+  if (!version) {
+    return packRawClusterDataV2(packable);
+  }
+
+  switch (version) {
+    case 'v1':
+      return packRawClusterDataV1(packable);
+    case 'v2':
+      return packRawClusterDataV2(packable);
+    default:
+      throw new Error(`Unsupported ClusterData version: ${version}`);
+  }
+}
+export function packRawClusterDataV1(packable: RawClusterDataV1): Uint8Array {
+  return ClusterDataV1.pack({
+    name: bytifyRawString(packable.name),
+    description: bytifyRawString(packable.description),
+  });
+}
+export function packRawClusterDataV2(packable: RawClusterDataV2): Uint8Array {
   return ClusterDataV2.pack({
     name: bytifyRawString(packable.name),
     description: bytifyRawString(packable.description),
@@ -33,19 +63,43 @@ export function packRawClusterData(packable: RawClusterData): Uint8Array {
   });
 }
 
-export function unpackToRawClusterData(unpackable: BytesLike): RawClusterData {
-  try {
-    const decoded = ClusterDataV2.unpack(unpackable);
-    return {
-      name: bufferToRawString(decoded.name),
-      description: bufferToRawString(decoded.description),
-      mutantId: decoded.mutantId,
-    };
-  } catch {
-    const decoded = ClusterDataV1.unpack(unpackable);
-    return {
-      name: bufferToRawString(decoded.name),
-      description: bufferToRawString(decoded.description),
-    };
+export function unpackToRawClusterData(unpackable: BytesLike): RawClusterData;
+export function unpackToRawClusterData(unpackable: BytesLike, version: 'v1'): RawClusterDataV1;
+export function unpackToRawClusterData(unpackable: BytesLike, version: 'v2'): RawClusterDataV2;
+export function unpackToRawClusterData(unpackable: BytesLike, version?: unknown): unknown {
+  if (version) {
+    switch (version) {
+      case 'v1':
+        return unpackToRawClusterDataV1(unpackable);
+      case 'v2':
+        return unpackToRawClusterDataV2(unpackable);
+      default:
+        throw new Error(`Unsupported ClusterData version: ${version}`);
+    }
   }
+
+  try {
+    return unpackToRawClusterDataV2(unpackable);
+  } catch {
+    try {
+      return unpackToRawClusterDataV1(unpackable);
+    } catch {
+      throw new Error(`Cannot unpack ClusterData, no matching molecule: ${bytes.hexify(unpackable)}`);
+    }
+  }
+}
+export function unpackToRawClusterDataV1(unpackable: BytesLike): RawClusterDataV1 {
+  const decoded = ClusterDataV1.unpack(unpackable);
+  return {
+    name: bufferToRawString(decoded.name),
+    description: bufferToRawString(decoded.description),
+  };
+}
+export function unpackToRawClusterDataV2(unpackable: BytesLike): RawClusterDataV2 {
+  const decoded = ClusterDataV2.unpack(unpackable);
+  return {
+    name: bufferToRawString(decoded.name),
+    description: bufferToRawString(decoded.description),
+    mutantId: decoded.mutantId,
+  };
 }

--- a/packages/core/src/codec/cluster.ts
+++ b/packages/core/src/codec/cluster.ts
@@ -2,6 +2,13 @@ import { blockchain, Hash } from '@ckb-lumos/base';
 import { bytes, BytesLike, molecule } from '@ckb-lumos/codec';
 import { bytifyRawString, bufferToRawString } from '../helpers';
 
+export const ClusterDataV1 = molecule.table(
+  {
+    name: blockchain.Bytes,
+    description: blockchain.Bytes,
+  },
+  ['name', 'description'],
+);
 export const ClusterDataV2 = molecule.table(
   {
     name: blockchain.Bytes,
@@ -9,14 +16,6 @@ export const ClusterDataV2 = molecule.table(
     mutantId: blockchain.BytesOpt,
   },
   ['name', 'description', 'mutantId'],
-);
-
-export const ClusterDataV1 = molecule.table(
-  {
-    name: blockchain.Bytes,
-    description: blockchain.Bytes,
-  },
-  ['name', 'description'],
 );
 
 export interface RawClusterDataV1 {
@@ -32,6 +31,10 @@ export type RawClusterData = RawClusterDataV2;
 
 export type ClusterDataVersion = 'v1' | 'v2';
 
+/**
+ * Pack RawClusterData to Uint8Array.
+ * Pass an optional "version" field to select a specific packing version.
+ */
 export function packRawClusterData(packable: RawClusterData): Uint8Array;
 export function packRawClusterData(packable: RawClusterDataV1, version: 'v1'): Uint8Array;
 export function packRawClusterData(packable: RawClusterDataV2, version: 'v2'): Uint8Array;
@@ -63,6 +66,10 @@ export function packRawClusterDataV2(packable: RawClusterDataV2): Uint8Array {
   });
 }
 
+/**
+ * Unpack Hex/Bytes to RawClusterData.
+ * Pass an optional "version" field to select a specific unpacking version.
+ */
 export function unpackToRawClusterData(unpackable: BytesLike): RawClusterData;
 export function unpackToRawClusterData(unpackable: BytesLike, version: 'v1'): RawClusterDataV1;
 export function unpackToRawClusterData(unpackable: BytesLike, version: 'v2'): RawClusterDataV2;

--- a/packages/core/src/config/predefined.ts
+++ b/packages/core/src/config/predefined.ts
@@ -15,12 +15,12 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
         {
           tags: ['v2', 'preview'],
           script: {
-            codeHash: '0xa32df38d2de1da82cbcb9e4467f8c18479596394eea977e471b75be5fe3e9c67',
+            codeHash: '0x5e063b4c0e7abeaa6a428df3b693521a3050934cf3b0ae97a800d1bc31449398',
             hashType: 'data1',
           },
           cellDep: {
             outPoint: {
-              txHash: '0xfad85d02822b7ee7c0fe9879c03fcaff695aa7ff2b7a7b740966bf49f47c29c1',
+              txHash: '0x06995b9fc19461a2bf9933e57b69af47a20bf0a5bc6c0ffcb85567a2c733f0a1',
               index: '0x0',
             },
             depType: 'code',
@@ -51,12 +51,12 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
         {
           tags: ['v2', 'preview'],
           script: {
-            codeHash: '0x5203a3baf931c15a809c4a0bb7041aebb73118281e31e8d104d926b8523977b1',
+            codeHash: '0x7366a61534fa7c7e6225ecc0d828ea3b5366adec2b58206f2ee84995fe030075',
             hashType: 'data1',
           },
           cellDep: {
             outPoint: {
-              txHash: '0xa23dbb38208fd50ce99404780a769784c77bd95a32e0af72c3a87de85d0bf1ba',
+              txHash: '0xfbceb70b2e683ef3a97865bb88e082e3e5366ee195a9c826e3c07d1026792fcd',
               index: '0x0',
             },
             depType: 'code',
@@ -87,12 +87,12 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
         {
           tags: ['v2', 'preview'],
           script: {
-            codeHash: '0x08e5cecab2bbdea9139534a822d46b82929e06f12f00c68343a88a58827cd3db',
+            codeHash: '0xbe8b9ce3d05a32c4bb26fe71cd5fc1407ce91e3a8b9e8719be2ab072cef1454b',
             hashType: 'data1',
           },
           cellDep: {
             outPoint: {
-              txHash: '0x4ca4dcba0f907f054ceace6061f6a143aeea80107eb48fa296d27af63a1714ea',
+              txHash: '0x0231ea581bbc38965e10a2659da326ae840c038a9d0d6849f458b51d94870104',
               index: '0x0',
             },
             depType: 'code',
@@ -109,12 +109,12 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
         {
           tags: ['v2', 'preview'],
           script: {
-            codeHash: '0x88850ac632eed604f0ad784394004db384d0eea8038a24eee83439687d79343f',
+            codeHash: '0xc986099b41d79ca1b2a56ce5874bcda8175440a17298ea5e2bbc3897736b8c21',
             hashType: 'data1',
           },
           cellDep: {
             outPoint: {
-              txHash: '0xde33357919460d527abf53ff61881e62e0b3afc5f4fb95b34783b5827e59d82d',
+              txHash: '0x53fdb9366637434ff685d0aca5e2a68a859b6fcaa4b608a7ecca0713fed0f5b7',
               index: '0x0',
             },
             depType: 'code',
@@ -136,7 +136,7 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
           },
           cellDep: {
             outPoint: {
-              txHash: '0xc4a70f8569649f63ca96ca8d2863f57403d5a6bf03c0b831b6400d0e5dc7dc36',
+              txHash: '0x3faf49cbd18fc99566079b534c3c05b2b29703d936e9c0b04234bcc686e076b1',
               index: '0x0',
             },
             depType: 'code',

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,6 +1,7 @@
 import { Config } from '@ckb-lumos/config-manager';
 import { CellDep } from '@ckb-lumos/base';
 import { ScriptId } from '../types';
+import { ClusterDataVersion } from '../codec';
 
 export interface SporeConfig<T extends string = string> {
   lumos: Config;
@@ -27,10 +28,11 @@ export interface SporeScript {
   tags: string[];
   script: ScriptId;
   cellDep: CellDep;
-  behaviors?: SporeScriptOptions;
+  behaviors?: SporeScriptBehaviors;
 }
 
-export interface SporeScriptOptions {
+export interface SporeScriptBehaviors {
   lockProxy?: boolean;
   cobuild?: boolean;
+  clusterDataVersion?: ClusterDataVersion;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         version: 4.17.21
     devDependencies:
       vitest:
-        specifier: ^1.1.0
-        version: 1.1.0(@types/node@20.4.1)
+        specifier: ^1.2.0
+        version: 1.2.0(@types/node@20.4.1)
 
 packages:
 
@@ -919,6 +919,10 @@ packages:
     resolution: {integrity: sha512-fILflsS66kGQ4iIBzYoxuQCWK1wQdy/ooguTofUk0KSxA+G5ZzH8WdU8mf6IU+5cMBW+j9u+eh+7kv63R3O9Tw==}
     dev: false
 
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
+
   /@types/is-ci@3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
     dependencies:
@@ -954,40 +958,41 @@ packages:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
     dev: true
 
-  /@vitest/expect@1.1.0:
-    resolution: {integrity: sha512-9IE2WWkcJo2BR9eqtY5MIo3TPmS50Pnwpm66A6neb2hvk/QSLfPXBz2qdiwUOQkwyFuuXEUj5380CbwfzW4+/w==}
+  /@vitest/expect@1.2.0:
+    resolution: {integrity: sha512-H+2bHzhyvgp32o7Pgj2h9RTHN0pgYaoi26Oo3mE+dCi1PAqV31kIIVfTbqMO3Bvshd5mIrJLc73EwSRrbol9Lw==}
     dependencies:
-      '@vitest/spy': 1.1.0
-      '@vitest/utils': 1.1.0
+      '@vitest/spy': 1.2.0
+      '@vitest/utils': 1.2.0
       chai: 4.3.10
     dev: true
 
-  /@vitest/runner@1.1.0:
-    resolution: {integrity: sha512-zdNLJ00pm5z/uhbWF6aeIJCGMSyTyWImy3Fcp9piRGvueERFlQFbUwCpzVce79OLm2UHk9iwaMSOaU9jVHgNVw==}
+  /@vitest/runner@1.2.0:
+    resolution: {integrity: sha512-vaJkDoQaNUTroT70OhM0NPznP7H3WyRwt4LvGwCVYs/llLaqhoSLnlIhUClZpbF5RgAee29KRcNz0FEhYcgxqA==}
     dependencies:
-      '@vitest/utils': 1.1.0
+      '@vitest/utils': 1.2.0
       p-limit: 5.0.0
       pathe: 1.1.1
     dev: true
 
-  /@vitest/snapshot@1.1.0:
-    resolution: {integrity: sha512-5O/wyZg09V5qmNmAlUgCBqflvn2ylgsWJRRuPrnHEfDNT6tQpQ8O1isNGgo+VxofISHqz961SG3iVvt3SPK/QQ==}
+  /@vitest/snapshot@1.2.0:
+    resolution: {integrity: sha512-P33EE7TrVgB3HDLllrjK/GG6WSnmUtWohbwcQqmm7TAk9AVHpdgf7M3F3qRHKm6vhr7x3eGIln7VH052Smo6Kw==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.1.0:
-    resolution: {integrity: sha512-sNOVSU/GE+7+P76qYo+VXdXhXffzWZcYIPQfmkiRxaNCSPiLANvQx5Mx6ZURJ/ndtEkUJEpvKLXqAYTKEY+lTg==}
+  /@vitest/spy@1.2.0:
+    resolution: {integrity: sha512-MNxSAfxUaCeowqyyGwC293yZgk7cECZU9wGb8N1pYQ0yOn/SIr8t0l9XnGRdQZvNV/ZHBYu6GO/W3tj5K3VN1Q==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/utils@1.1.0:
-    resolution: {integrity: sha512-z+s510fKmYz4Y41XhNs3vcuFTFhcij2YF7F8VQfMEYAAUfqQh0Zfg7+w9xdgFGhPf3tX3TicAe+8BDITk6ampQ==}
+  /@vitest/utils@1.2.0:
+    resolution: {integrity: sha512-FyD5bpugsXlwVpTcGLDf3wSPYy8g541fQt14qtzo8mJ4LdEpDKZ9mQy2+qdJm2TZRpjY5JLXihXCgIxiRJgi5g==}
     dependencies:
       diff-sequences: 29.6.3
+      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
     dev: true
@@ -1209,7 +1214,7 @@ packages:
       check-error: 1.0.3
       deep-eql: 4.1.3
       get-func-name: 2.0.2
-      loupe: 2.3.6
+      loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: true
@@ -1579,6 +1584,12 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.5
     dev: true
 
   /event-target-shim@5.0.1:
@@ -2238,13 +2249,6 @@ packages:
       slice-ansi: 5.0.0
       strip-ansi: 7.1.0
       wrap-ansi: 8.1.0
-    dev: true
-
-  /loupe@2.3.6:
-    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
-    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
-    dependencies:
-      get-func-name: 2.0.2
     dev: true
 
   /loupe@2.3.7:
@@ -3305,8 +3309,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@1.1.0(@types/node@20.4.1):
-    resolution: {integrity: sha512-jV48DDUxGLEBdHCQvxL1mEh7+naVy+nhUUUaPAZLd3FJgXuxQiewHcfeZebbJ6onDqNGkP4r3MhQ342PRlG81Q==}
+  /vite-node@1.2.0(@types/node@20.4.1):
+    resolution: {integrity: sha512-ETnQTHeAbbOxl7/pyBck9oAPZZZo+kYnFt1uQDD+hPReOc+wCjXw4r4jHriBRuVDB5isHmPXxrfc1yJnfBERqg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -3362,8 +3366,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.1.0(@types/node@20.4.1):
-    resolution: {integrity: sha512-oDFiCrw7dd3Jf06HoMtSRARivvyjHJaTxikFxuqJjO76U436PqlVw1uLn7a8OSPrhSfMGVaRakKpA2lePdw79A==}
+  /vitest@1.2.0(@types/node@20.4.1):
+    resolution: {integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -3388,11 +3392,11 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.4.1
-      '@vitest/expect': 1.1.0
-      '@vitest/runner': 1.1.0
-      '@vitest/snapshot': 1.1.0
-      '@vitest/spy': 1.1.0
-      '@vitest/utils': 1.1.0
+      '@vitest/expect': 1.2.0
+      '@vitest/runner': 1.2.0
+      '@vitest/snapshot': 1.2.0
+      '@vitest/spy': 1.2.0
+      '@vitest/utils': 1.2.0
       acorn-walk: 8.3.1
       cac: 6.7.14
       chai: 4.3.10
@@ -3407,7 +3411,7 @@ packages:
       tinybench: 2.5.1
       tinypool: 0.8.1
       vite: 5.0.10(@types/node@20.4.1)
-      vite-node: 1.1.0(@types/node@20.4.1)
+      vite-node: 1.2.0(@types/node@20.4.1)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,26 +81,26 @@ importers:
   packages/core:
     dependencies:
       '@ckb-lumos/base':
-        specifier: ^0.22.0-next.3
-        version: 0.22.0-next.3
+        specifier: ^0.22.0-next.4
+        version: 0.22.0-next.4
       '@ckb-lumos/bi':
-        specifier: ^0.22.0-next.3
-        version: 0.22.0-next.3
+        specifier: ^0.22.0-next.4
+        version: 0.22.0-next.4
       '@ckb-lumos/codec':
-        specifier: ^0.22.0-next.3
-        version: 0.22.0-next.3
+        specifier: ^0.22.0-next.4
+        version: 0.22.0-next.4
       '@ckb-lumos/common-scripts':
-        specifier: ^0.22.0-next.3
-        version: 0.22.0-next.3
+        specifier: ^0.22.0-next.4
+        version: 0.22.0-next.4
       '@ckb-lumos/config-manager':
-        specifier: ^0.22.0-next.3
-        version: 0.22.0-next.3
+        specifier: ^0.22.0-next.4
+        version: 0.22.0-next.4
       '@ckb-lumos/lumos':
-        specifier: ^0.22.0-next.3
-        version: 0.22.0-next.3
+        specifier: ^0.22.0-next.4
+        version: 0.22.0-next.4
       '@ckb-lumos/rpc':
-        specifier: ^0.22.0-next.3
-        version: 0.22.0-next.3
+        specifier: ^0.22.0-next.4
+        version: 0.22.0-next.4
       '@exact-realty/multipart-parser':
         specifier: ^1.0.9
         version: 1.0.9
@@ -326,13 +326,13 @@ packages:
       prettier: 2.8.7
     dev: true
 
-  /@ckb-lumos/base@0.22.0-next.3:
-    resolution: {integrity: sha512-lHu7XLEVPAuRKmrsjrSy8iedN/LrZ7rP8ZvbkcWO8NS07bXdzrRAs/GIx1Ml9xGKpv6akLGVek3oXhQGggnj/w==}
+  /@ckb-lumos/base@0.22.0-next.4:
+    resolution: {integrity: sha512-7hjAkyllB/QMz3VaGbIxAb2zBtdChblfXvn2/FaD9udJvTAvJNcwkExp+k4tSpJFyMrdhTCFJ9EmgStuG1XqDw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.3
-      '@ckb-lumos/codec': 0.22.0-next.3
-      '@ckb-lumos/toolkit': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.4
+      '@ckb-lumos/codec': 0.22.0-next.4
+      '@ckb-lumos/toolkit': 0.22.0-next.4
       '@types/blake2b': 2.1.0
       '@types/lodash.isequal': 4.5.6
       blake2b: 2.1.4
@@ -340,71 +340,73 @@ packages:
       lodash.isequal: 4.5.0
     dev: false
 
-  /@ckb-lumos/bi@0.22.0-next.3:
-    resolution: {integrity: sha512-4vA3512b6QLkoqZxVhbB6Z1LuqbXNkQwlVIWJXzSZQsYCt7iq8TgkSc9mPRYm17SXIp5BnsC5HN/qtlxHSfv1g==}
+  /@ckb-lumos/bi@0.22.0-next.4:
+    resolution: {integrity: sha512-OlAfmWOty3vpCMUUQhQpxd7aun6Q1+hmBN10ZIdiR3n0CEMrj2dqZNSCtCDt/DfLWI+WfqVN71MO737cJ8cm7g==}
     engines: {node: '>=12.0.0'}
     dependencies:
       jsbi: 4.3.0
     dev: false
 
-  /@ckb-lumos/ckb-indexer@0.22.0-next.3:
-    resolution: {integrity: sha512-Y6LzyGW1ItQ1RDSIcGbqiIVVSaVpF2LH8eOI3o4sDY35jB/AfLN51Dy3AfHeeAXbHM29mRxOGSCssK24O+Xy5A==}
+  /@ckb-lumos/ckb-indexer@0.22.0-next.4:
+    resolution: {integrity: sha512-3NIqEFtgsbNAef23uVg1ANapvPH/IRBhT9F1pUUHe9lVOVsdbsLGj6oXnjfJ+zkQMhJbckVHH4dlZgDbZdbYuQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/bi': 0.22.0-next.3
-      '@ckb-lumos/codec': 0.22.0-next.3
-      '@ckb-lumos/rpc': 0.22.0-next.3
-      '@ckb-lumos/toolkit': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/bi': 0.22.0-next.4
+      '@ckb-lumos/codec': 0.22.0-next.4
+      '@ckb-lumos/rpc': 0.22.0-next.4
+      '@ckb-lumos/toolkit': 0.22.0-next.4
       cross-fetch: 3.1.8
       events: 3.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/codec@0.22.0-next.3:
-    resolution: {integrity: sha512-VBmb4vQ/iXTG/J0vi5f61ekpadX1XlJEF5NubtiJtAsaCFHjFkExS8PHxePEVIJVxy5YqZu0/AcZXnHDl9P40w==}
+  /@ckb-lumos/codec@0.22.0-next.4:
+    resolution: {integrity: sha512-4oV9Wn639+V5jYr1tbTJqpuRHVhaXcHZF7K1Ucb5ssMivr47Kb0Gl9DTQgq4jVgvWNIyfo1+DTTzdDajQF6DcQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.4
     dev: false
 
-  /@ckb-lumos/common-scripts@0.22.0-next.3:
-    resolution: {integrity: sha512-i7eXxgGJE5a9uhKmehNrQAfPhvMW0lA5yCfFxY0fpLMeymj9bFGVUXiEk/8XLpMZgwIRFRYOSEbXXkw3tE8HUA==}
+  /@ckb-lumos/common-scripts@0.22.0-next.4:
+    resolution: {integrity: sha512-STTF6G99UC93ayU9KNRxANNhe1GCh1pFlJf4jdB84904/9mTiMDoL1ZwN7yJqgc6aGC8Hx5VW+8hxm133qXDUA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/bi': 0.22.0-next.3
-      '@ckb-lumos/codec': 0.22.0-next.3
-      '@ckb-lumos/config-manager': 0.22.0-next.3
-      '@ckb-lumos/helpers': 0.22.0-next.3
-      '@ckb-lumos/rpc': 0.22.0-next.3
-      '@ckb-lumos/toolkit': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/bi': 0.22.0-next.4
+      '@ckb-lumos/codec': 0.22.0-next.4
+      '@ckb-lumos/config-manager': 0.22.0-next.4
+      '@ckb-lumos/helpers': 0.22.0-next.4
+      '@ckb-lumos/rpc': 0.22.0-next.4
+      '@ckb-lumos/toolkit': 0.22.0-next.4
+      bech32: 2.0.0
+      bs58: 5.0.0
       immutable: 4.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/config-manager@0.22.0-next.3:
-    resolution: {integrity: sha512-fkW20X17oCik9PZ8cxZNh4SIubkVtU4KR6LO7solUZ2mgrTQVDW6U8+wynkFSUvKyr05lEWa74tsVZtlW6x24A==}
+  /@ckb-lumos/config-manager@0.22.0-next.4:
+    resolution: {integrity: sha512-ZO/I1C+pBTG09HQlLLGAC40ljtDmNQlpTvP4c/k/tMBKnrcgBfgUmKYMF0aCunfT4jmIqS3G8Z6615qu1liF9g==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/bi': 0.22.0-next.3
-      '@ckb-lumos/codec': 0.22.0-next.3
-      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/bi': 0.22.0-next.4
+      '@ckb-lumos/codec': 0.22.0-next.4
+      '@ckb-lumos/rpc': 0.22.0-next.4
       '@types/deep-freeze-strict': 1.1.0
       deep-freeze-strict: 1.1.1
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/hd@0.22.0-next.3:
-    resolution: {integrity: sha512-zxL1LqiYJuGuwWvfe7e2qgih56dRogfvnFaJLkUKG6riDm7jhBm0bzS+FlIpEMI+RkY/XPbUcvf4cSocjtRxfg==}
+  /@ckb-lumos/hd@0.22.0-next.4:
+    resolution: {integrity: sha512-PV0vcxWOiMVOBq0aJ8TxRBpG9sqpUpdZ1Y8YIq7o0ush3+8+o1xkefw7ZT+xRXUWE+2Ep63GeLRdN3VRLgl8Ew==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/bi': 0.22.0-next.4
       bn.js: 5.2.1
       elliptic: 6.5.4
       scrypt-js: 3.0.1
@@ -412,82 +414,82 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@ckb-lumos/helpers@0.22.0-next.3:
-    resolution: {integrity: sha512-qJPVDjcIFGwLKOPA9Xvwu5wcGrh9nlXhYCjnlHbTYO6uWRnIltBusCIBn0PapmwxbgLb2qagkCmMfbgwyZ4gfQ==}
+  /@ckb-lumos/helpers@0.22.0-next.4:
+    resolution: {integrity: sha512-aO11dRke83r003rDfgicaJkCX2yjirdHfr4VJRguL24T4P9qZC0VrhxqsRW7UeralRzVQYg1eTwFrD6jLA11GA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/bi': 0.22.0-next.3
-      '@ckb-lumos/codec': 0.22.0-next.3
-      '@ckb-lumos/config-manager': 0.22.0-next.3
-      '@ckb-lumos/toolkit': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/bi': 0.22.0-next.4
+      '@ckb-lumos/codec': 0.22.0-next.4
+      '@ckb-lumos/config-manager': 0.22.0-next.4
+      '@ckb-lumos/toolkit': 0.22.0-next.4
       bech32: 2.0.0
       immutable: 4.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/light-client@0.22.0-next.3:
-    resolution: {integrity: sha512-KjrlwrsuTALPJ/P3lRA661MPpEJMsszH46lkS5pkdJ4+5x6UNf9SuUqA/N8dtpcnPZq6dUVJiN0wd3yqroHygw==}
+  /@ckb-lumos/light-client@0.22.0-next.4:
+    resolution: {integrity: sha512-n3v/bBinrTo465QhCsGd5tQ6eY7S1Wq0VeTJtZAQGjqdsOhRhX7XB+Fjf/oJYl9NZFj8dESrfx1APdym8McEcg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
-      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.4
+      '@ckb-lumos/rpc': 0.22.0-next.4
       cross-fetch: 3.1.8
       events: 3.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/lumos@0.22.0-next.3:
-    resolution: {integrity: sha512-wagcumbQCPHTkCINy6D73PY2s9bESijvuxfj4AB3cLCiOEdg+SgpQuMhiaDx96H4pkFeeRKF0beljfVtI0+i9Q==}
+  /@ckb-lumos/lumos@0.22.0-next.4:
+    resolution: {integrity: sha512-5+wdI8J+JUlF/PGVa53rYfybfccp63Tn1d/eNk3JwM5SYPT2yGp42fqMOL/1zqDDsMp1a8yHJ4gASHUK6843Yg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/bi': 0.22.0-next.3
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
-      '@ckb-lumos/codec': 0.22.0-next.3
-      '@ckb-lumos/common-scripts': 0.22.0-next.3
-      '@ckb-lumos/config-manager': 0.22.0-next.3
-      '@ckb-lumos/hd': 0.22.0-next.3
-      '@ckb-lumos/helpers': 0.22.0-next.3
-      '@ckb-lumos/light-client': 0.22.0-next.3
-      '@ckb-lumos/rpc': 0.22.0-next.3
-      '@ckb-lumos/toolkit': 0.22.0-next.3
-      '@ckb-lumos/transaction-manager': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/bi': 0.22.0-next.4
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.4
+      '@ckb-lumos/codec': 0.22.0-next.4
+      '@ckb-lumos/common-scripts': 0.22.0-next.4
+      '@ckb-lumos/config-manager': 0.22.0-next.4
+      '@ckb-lumos/hd': 0.22.0-next.4
+      '@ckb-lumos/helpers': 0.22.0-next.4
+      '@ckb-lumos/light-client': 0.22.0-next.4
+      '@ckb-lumos/rpc': 0.22.0-next.4
+      '@ckb-lumos/toolkit': 0.22.0-next.4
+      '@ckb-lumos/transaction-manager': 0.22.0-next.4
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/rpc@0.22.0-next.3:
-    resolution: {integrity: sha512-50ej2nBkHQgV5gcvkJv6Pa61vTXuiQxPcg3tr/lY7OUQ3dta1O3VkIADfP2k7P9busv9SVeffxQuEauUORP+eg==}
+  /@ckb-lumos/rpc@0.22.0-next.4:
+    resolution: {integrity: sha512-mhkkPXv70PzODvqUNYlOCn+7hNOTIj9p+h4px8BpJfoB0SZdO9i/bmF2CINbh3LvFUj0oWBkrCFvHCBVLVdzZA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/bi': 0.22.0-next.4
       abort-controller: 3.0.0
       cross-fetch: 3.1.8
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/toolkit@0.22.0-next.3:
-    resolution: {integrity: sha512-+3nVXcH6P1G18h+kMmSKShcBWNwiPJZ6OUqit15uhFQxu/TAiUSk9C/xHAGUpQCXBIoIWvVXDMZThYCyx3yk8Q==}
+  /@ckb-lumos/toolkit@0.22.0-next.4:
+    resolution: {integrity: sha512-vSqMgwUHKNFxjQvanfPCGDfPtAxSYUGh6Pvg6ThJX9BIE9rits74eCobxfeWym9Qjp9mt+WwY4D0S6DI1uT5Tw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.4
     dev: false
 
-  /@ckb-lumos/transaction-manager@0.22.0-next.3:
-    resolution: {integrity: sha512-yUNo3t6qnSWNoL7M729YAVn8JjpF97r3PeS4j1chdTB+Cu+zVqyiLtQRyGZ9VFdFs56HmRt4pmEwuLKEkIIGOg==}
+  /@ckb-lumos/transaction-manager@0.22.0-next.4:
+    resolution: {integrity: sha512-2EAT/BOrQeNDetcMPAML5F1yqFHuruOVNfKPnYbsqTWjo/Aa8Oj/fpD63ANjo9D9dVdWoMhWRq1BwCNTGwJfTg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.3
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
-      '@ckb-lumos/codec': 0.22.0-next.3
-      '@ckb-lumos/rpc': 0.22.0-next.3
-      '@ckb-lumos/toolkit': 0.22.0-next.3
+      '@ckb-lumos/base': 0.22.0-next.4
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.4
+      '@ckb-lumos/codec': 0.22.0-next.4
+      '@ckb-lumos/rpc': 0.22.0-next.4
+      '@ckb-lumos/toolkit': 0.22.0-next.4
       immutable: 4.3.0
     transitivePeerDependencies:
       - encoding
@@ -1113,6 +1115,10 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: false
 
+  /base-x@4.0.0:
+    resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
+    dev: false
+
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
@@ -1171,6 +1177,12 @@ packages:
 
   /brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+    dev: false
+
+  /bs58@5.0.0:
+    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
+    dependencies:
+      base-x: 4.0.0
     dev: false
 
   /buffer@6.0.3:


### PR DESCRIPTION
## Changes
- Replaced v2 preview contracts with v1-compatible version
  - sproe-contract: https://github.com/sporeprotocol/spore-contract/pull/50
  - spore-devenv: https://github.com/sporeprotocol/spore-devenv/pull/4
- Supported packing or unpacking v1/v2 version of ClusterData
- Enabled cluster v1 related tests in the test workflow
- Bumped vitest to 1.2.0
- Bumped lumos to 0.22.0-next.4