### PR TITLE
chore(sdk): add mainnet predefined config

### DIFF
--- a/.changeset/slimy-peas-share.md
+++ b/.changeset/slimy-peas-share.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Add predefined SporeConfig for Mainnet

--- a/packages/core/src/config/predefined.ts
+++ b/packages/core/src/config/predefined.ts
@@ -1,14 +1,14 @@
 import { predefined } from '@ckb-lumos/config-manager';
 import { SporeConfig } from './types';
 
-export type PredefinedSporeConfigScriptName = 'Spore' | 'Cluster' | 'ClusterProxy' | 'ClusterAgent' | 'Mutant' | 'Lua';
+export type PredefinedTestnetSporeScriptName = 'Spore' | 'Cluster' | 'ClusterProxy' | 'ClusterAgent' | 'Mutant' | 'Lua';
 
-const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
+const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedTestnetSporeScriptName> = {
   lumos: predefined.AGGRON4,
   ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
   ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
   maxTransactionSize: 500 * 1024, // 500 KB
-  defaultTags: ['v2'],
+  defaultTags: ['preview'],
   scripts: {
     Spore: {
       versions: [
@@ -169,6 +169,67 @@ const TESTNET_SPORE_CONFIG: SporeConfig<PredefinedSporeConfigScriptName> = {
   },
 };
 
+export type PredefinedMainnetSporeScriptName = 'Spore' | 'Cluster';
+
+const MAINNET_SPORE_CONFIG: SporeConfig<PredefinedMainnetSporeScriptName> = {
+  lumos: predefined.LINA,
+  ckbNodeUrl: 'https://mainnet.ckb.dev/rpc',
+  ckbIndexerUrl: 'https://mainnet.ckb.dev/indexer',
+  maxTransactionSize: 500 * 1024, // 500 KB
+  defaultTags: ['latest'],
+  scripts: {
+    Spore: {
+      versions: [
+        {
+          tags: ['v2', 'latest'],
+          script: {
+            codeHash: '0x4a4dce1df3dffff7f8b2cd7dff7303df3b6150c9788cb75dcf6747247132b9f5',
+            hashType: 'data1',
+          },
+          cellDep: {
+            outPoint: {
+              txHash: '0x96b198fb5ddbd1eed57ed667068f1f1e55d07907b4c0dbd38675a69ea1b69824',
+              index: '0x0',
+            },
+            depType: 'code',
+          },
+          behaviors: {
+            lockProxy: true,
+            cobuild: true,
+          },
+        },
+      ],
+    },
+    Cluster: {
+      versions: [
+        {
+          tags: ['v2', 'latest'],
+          script: {
+            codeHash: '0x7366a61534fa7c7e6225ecc0d828ea3b5366adec2b58206f2ee84995fe030075',
+            hashType: 'data1',
+          },
+          cellDep: {
+            outPoint: {
+              txHash: '0xe464b7fb9311c5e2820e61c99afc615d6b98bdefbe318c34868c010cbd0dc938',
+              index: '0x0',
+            },
+            depType: 'code',
+          },
+          behaviors: {
+            lockProxy: true,
+            cobuild: true,
+          },
+        },
+      ],
+    },
+  },
+};
+
 export const predefinedSporeConfigs = {
+  /**
+   * @deprecated Use `Testnet` instead.
+   */
   Aggron4: TESTNET_SPORE_CONFIG,
+  Testnet: TESTNET_SPORE_CONFIG,
+  Mainnet: MAINNET_SPORE_CONFIG,
 };


### PR DESCRIPTION
## Changes
- Marked predefined config `Aggron4` as deprecated, should use `Testnet` instead
- Added predefined config `Mainnet` for mainnet (version: 0.2.2-beta.1)
  - Spore: https://github.com/sporeprotocol/spore-contract/blob/837b68efe3e4f18eb2c69d96d77ed419ad38d98b/deployment/migration/mainnet/spore/2024-01-25-0.2.2-beta.1.json
  - Cluster: https://github.com/sporeprotocol/spore-contract/blob/837b68efe3e4f18eb2c69d96d77ed419ad38d98b/deployment/migration/mainnet/cluster/2024-01-23-0.2.2-beta.1.json
  
## Reference
- https://github.com/sporeprotocol/spore-contract/pull/52
- https://github.com/sporeprotocol/spore-contract/pull/55