### PR TITLE
fix(sdk): duplicated capacity collection

### DIFF
--- a/.changeset/proud-phones-camp.md
+++ b/.changeset/proud-phones-camp.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Fix duplicated capacity collection in the "createSpore" API

--- a/packages/core/src/api/composed/spore/createSpore.ts
+++ b/packages/core/src/api/composed/spore/createSpore.ts
@@ -70,15 +70,7 @@ export async function createSpore(props: {
   });
   txSkeleton = injectNewSporeResult.txSkeleton;
 
-  // Inject needed capacity
-  const injectNeededCapacityResult = await injectNeededCapacity({
-    txSkeleton,
-    fromInfos: props.fromInfos,
-    changeAddress: props.changeAddress,
-    config: config.lumos,
-  });
-  txSkeleton = injectNeededCapacityResult.txSkeleton;
-
+  // Inject needed capacity and pay fee
   const injectCapacityAndPayFeeResult = await injectCapacityAndPayFee({
     txSkeleton,
     fromInfos: props.fromInfos,


### PR DESCRIPTION
## Changes
- Fixed a duplicated capacity collection issue in the `createSpore` API

## Related issues
- resolves #84 