### PR TITLE
feat: export co-build related interfaces for assembling witness hex string

### DIFF
--- a/.changeset/ten-knives-join.md
+++ b/.changeset/ten-knives-join.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+slipt co-build generation interfaces to export pure assembly functions

--- a/packages/core/src/cobuild/action/cluster/createCluster.ts
+++ b/packages/core/src/cobuild/action/cluster/createCluster.ts
@@ -1,22 +1,16 @@
-import { helpers, utils } from '@ckb-lumos/lumos';
+import { Cell, helpers, utils } from '@ckb-lumos/lumos';
 import { bytes, UnpackResult } from '@ckb-lumos/codec';
 import { SporeAction } from '../../codec/sporeAction';
 import { Action, ScriptInfo } from '../../codec/buildingPacket';
 import { createRawBuildingPacket } from '../../base/buildingPacket';
 import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
 
-export function generateCreateClusterAction(props: {
-  txSkeleton: helpers.TransactionSkeletonType;
-  outputIndex: number;
-}): {
+export function assembleCreateClusterAction(clusterOutput: Cell | undefined): {
   actions: UnpackResult<typeof Action>[];
   scriptInfos: UnpackResult<typeof ScriptInfo>[];
 } {
   const actions: UnpackResult<typeof Action>[] = [];
   const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
-
-  let txSkeleton = props.txSkeleton;
-  const clusterOutput = txSkeleton.get('outputs').get(props.outputIndex);
 
   const clusterType = clusterOutput!.cellOutput.type!;
   const clusterTypeHash = utils.computeScriptHash(clusterType);
@@ -46,6 +40,18 @@ export function generateCreateClusterAction(props: {
     actions,
     scriptInfos,
   };
+}
+
+export function generateCreateClusterAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  let txSkeleton = props.txSkeleton;
+  const clusterOutput = txSkeleton.get('outputs').get(props.outputIndex);
+  return assembleCreateClusterAction(clusterOutput);
 }
 
 export function generateCreateClusterBuildingPacket(props: {

--- a/packages/core/src/cobuild/action/cluster/transferCluster.ts
+++ b/packages/core/src/cobuild/action/cluster/transferCluster.ts
@@ -1,24 +1,19 @@
-import { helpers, utils } from '@ckb-lumos/lumos';
+import { Cell, helpers, utils } from '@ckb-lumos/lumos';
 import { bytes, UnpackResult } from '@ckb-lumos/codec';
 import { SporeAction } from '../../codec/sporeAction';
 import { Action, ScriptInfo } from '../../codec/buildingPacket';
 import { createRawBuildingPacket } from '../../base/buildingPacket';
 import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
 
-export function generateTransferClusterAction(props: {
-  txSkeleton: helpers.TransactionSkeletonType;
-  inputIndex: number;
-  outputIndex: number;
-}): {
+export function assembleTransferClusterAction(
+  clusterInput: Cell | undefined,
+  clusterOutput: Cell | undefined,
+): {
   actions: UnpackResult<typeof Action>[];
   scriptInfos: UnpackResult<typeof ScriptInfo>[];
 } {
   const actions: UnpackResult<typeof Action>[] = [];
   const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
-
-  let txSkeleton = props.txSkeleton;
-  const clusterInput = txSkeleton.get('inputs').get(props.inputIndex);
-  const clusterOutput = txSkeleton.get('outputs').get(props.outputIndex);
 
   const clusterType = clusterOutput!.cellOutput.type!;
   const clusterTypeHash = utils.computeScriptHash(clusterType);
@@ -51,6 +46,20 @@ export function generateTransferClusterAction(props: {
     actions,
     scriptInfos,
   };
+}
+
+export function generateTransferClusterAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  let txSkeleton = props.txSkeleton;
+  const clusterInput = txSkeleton.get('inputs').get(props.inputIndex);
+  const clusterOutput = txSkeleton.get('outputs').get(props.outputIndex);
+  return assembleTransferClusterAction(clusterInput, clusterOutput);
 }
 
 export function generateTransferClusterBuildingPacket(props: {

--- a/packages/core/src/cobuild/action/spore/meltSpore.ts
+++ b/packages/core/src/cobuild/action/spore/meltSpore.ts
@@ -1,19 +1,16 @@
-import { helpers, utils } from '@ckb-lumos/lumos';
+import { Cell, helpers, utils } from '@ckb-lumos/lumos';
 import { bytes, UnpackResult } from '@ckb-lumos/codec';
 import { SporeAction } from '../../codec/sporeAction';
 import { Action, ScriptInfo } from '../../codec/buildingPacket';
 import { createRawBuildingPacket } from '../../base/buildingPacket';
 import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
 
-export function generateMeltSporeAction(props: { txSkeleton: helpers.TransactionSkeletonType; inputIndex: number }): {
+export function assembleMeltSporeAction(sporeInput: Cell | undefined): {
   actions: UnpackResult<typeof Action>[];
   scriptInfos: UnpackResult<typeof ScriptInfo>[];
 } {
   const actions: UnpackResult<typeof Action>[] = [];
   const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
-
-  let txSkeleton = props.txSkeleton;
-  const sporeInput = txSkeleton.get('inputs').get(props.inputIndex);
 
   const sporeType = sporeInput!.cellOutput.type!;
   const sporeTypeHash = utils.computeScriptHash(sporeType);
@@ -42,6 +39,15 @@ export function generateMeltSporeAction(props: { txSkeleton: helpers.Transaction
     actions,
     scriptInfos,
   };
+}
+
+export function generateMeltSporeAction(props: { txSkeleton: helpers.TransactionSkeletonType; inputIndex: number }): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  let txSkeleton = props.txSkeleton;
+  const sporeInput = txSkeleton.get('inputs').get(props.inputIndex);
+  return assembleMeltSporeAction(sporeInput);
 }
 
 export function generateMeltSporeBuildingPacket(props: {

--- a/packages/core/src/cobuild/action/spore/transferSpore.ts
+++ b/packages/core/src/cobuild/action/spore/transferSpore.ts
@@ -1,24 +1,19 @@
-import { helpers, utils } from '@ckb-lumos/lumos';
+import { Cell, helpers, utils } from '@ckb-lumos/lumos';
 import { bytes, UnpackResult } from '@ckb-lumos/codec';
 import { SporeAction } from '../../codec/sporeAction';
 import { Action, ScriptInfo } from '../../codec/buildingPacket';
 import { createRawBuildingPacket } from '../../base/buildingPacket';
 import { createSporeScriptInfoFromTemplate } from '../../base/sporeScriptInfo';
 
-export function generateTransferSporeAction(props: {
-  txSkeleton: helpers.TransactionSkeletonType;
-  inputIndex: number;
-  outputIndex: number;
-}): {
+export function assembleTransferSporeAction(
+  sporeInput: Cell | undefined,
+  sporeOutput: Cell | undefined,
+): {
   actions: UnpackResult<typeof Action>[];
   scriptInfos: UnpackResult<typeof ScriptInfo>[];
 } {
   const actions: UnpackResult<typeof Action>[] = [];
   const scriptInfos: UnpackResult<typeof ScriptInfo>[] = [];
-
-  let txSkeleton = props.txSkeleton;
-  const sporeInput = txSkeleton.get('inputs').get(props.inputIndex);
-  const sporeOutput = txSkeleton.get('outputs').get(props.outputIndex);
 
   const sporeType = sporeOutput!.cellOutput.type!;
   const sporeTypeHash = utils.computeScriptHash(sporeType);
@@ -51,6 +46,20 @@ export function generateTransferSporeAction(props: {
     actions,
     scriptInfos,
   };
+}
+
+export function generateTransferSporeAction(props: {
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndex: number;
+  outputIndex: number;
+}): {
+  actions: UnpackResult<typeof Action>[];
+  scriptInfos: UnpackResult<typeof ScriptInfo>[];
+} {
+  let txSkeleton = props.txSkeleton;
+  const sporeInput = txSkeleton.get('inputs').get(props.inputIndex);
+  const sporeOutput = txSkeleton.get('outputs').get(props.outputIndex);
+  return assembleTransferSporeAction(sporeInput, sporeOutput);
 }
 
 export function generateTransferSporeBuildingPacket(props: {


### PR DESCRIPTION
# Description
JoyID was not supported by Lumos and the CoBuild related assembly logic are highly integrated with Lumos, that caused a problem: JoyID can not generate CoBuild witness data which that `spore-contract` has to verify.

solution here is to export CoBuild witness assembly related interfaces.