### PR TITLE
chore: bump to 0.2.0-beta.3

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,11 +13,13 @@
     "nine-bottles-report",
     "old-oranges-invite",
     "polite-donuts-begin",
+    "proud-phones-camp",
     "slimy-peas-share",
     "slow-tools-flow",
     "small-lobsters-jam",
     "stale-ghosts-lie",
     "strange-forks-brake",
+    "ten-knives-join",
     "thirty-bugs-applaud",
     "three-cows-unite",
     "twenty-planets-rest"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @spore-sdk/core
 
+## 0.2.0-beta.3
+
+### Patch Changes
+
+- a605f5f: Fix duplicated capacity collection in the "createSpore" API
+- 858c8fb: slipt co-build generation interfaces to export pure assembly functions
+
 ## 0.2.0-beta.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spore-sdk/core",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "license": "MIT",
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
# Description
publish version `0.2.0-beta.3`