### PR TITLE
feat: add input cells pre-injection parameter

### DIFF
--- a/.changeset/honest-rice-vanish.md
+++ b/.changeset/honest-rice-vanish.md
@@ -3,3 +3,4 @@
 ---
 
 enable interface `createSpore` and `meltThenCreateSpore` to accept input cells pre-injection
+add `createMultipleSpores` interface to create multiple spores in one transaction

--- a/.changeset/honest-rice-vanish.md
+++ b/.changeset/honest-rice-vanish.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+enable interface `createSpore` and `meltThenCreateSpore` to accept input cells pre-injection

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,7 @@ jobs:
         env:
           VITE_ACCOUNT_CHARLIE: ${{ secrets.ACCOUNT_CHARLIE }}
           VITE_ACCOUNT_ALICE: ${{ secrets.ACCOUNT_ALICE }}
+          VITE_ACCOUNT_BOB: ${{ secrets.ACCOUNT_BOB }}
 
       - name: Prepare spore-sdk
         working-directory: spore-sdk
@@ -79,5 +80,6 @@ jobs:
         env:
           VITE_ACCOUNT_CHARLIE: ${{ secrets.ACCOUNT_CHARLIE }}
           VITE_ACCOUNT_ALICE: ${{ secrets.ACCOUNT_ALICE }}
+          VITE_ACCOUNT_BOB: ${{ secrets.ACCOUNT_BOB }}
           VITE_TEST_CLUSTER_V1: true
           VITE_NETWORK: devnet

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -19,7 +19,7 @@ import { SporeAction, WitnessLayout } from '../cobuild';
 
 describe('Spore', () => {
   const { rpc, config } = TEST_ENV;
-  const { CHARLIE, ALICE } = TEST_ACCOUNTS;
+  const { CHARLIE, ALICE, BOB } = TEST_ACCOUNTS;
 
   async function getLiveCell(account: Account): Promise<Cell | undefined> {
     const indexer = new Indexer(config.ckbIndexerUrl);
@@ -163,10 +163,10 @@ describe('Spore', () => {
               contentType: 'text/plain',
               content: bytifyRawString('content-2'),
             },
-            toLock: ALICE.lock,
+            toLock: CHARLIE.lock,
           },
         ],
-        fromInfos: [CHARLIE.address],
+        fromInfos: [BOB.address],
         config,
       });
 
@@ -179,13 +179,24 @@ describe('Spore', () => {
         console.log(JSON.stringify(actionsData, null, 2));
       }
 
-      await signAndOrSendTransaction({
-        account: CHARLIE,
+      const { hash } = await signAndOrSendTransaction({
+        account: BOB,
         txSkeleton,
         config,
         rpc,
         send: true,
       });
+      if (hash) {
+        for (const outputIndex of outputIndices) {
+          SPORE_OUTPOINT_RECORDS.push({
+            outPoint: {
+              txHash: hash,
+              index: BI.from(outputIndex).toHexString(),
+            },
+            account: CHARLIE,
+          });
+        }
+      }
     });
   }, 0);
 

--- a/packages/core/src/__tests__/Spore.test.ts
+++ b/packages/core/src/__tests__/Spore.test.ts
@@ -1,18 +1,9 @@
 import { describe, expect, it, afterAll } from 'vitest';
-import { BI } from '@ckb-lumos/lumos';
+import { BI, Cell, Indexer } from '@ckb-lumos/lumos';
 import { getSporeScript } from '../config';
-import { unpackToRawMutantArgs } from '../codec';
-import { bufferToRawString, bytifyRawString } from '../helpers';
-import {
-  createSpore,
-  transferSpore,
-  meltSpore,
-  getSporeByOutPoint,
-  getMutantById,
-  createCluster,
-  getClusterByOutPoint,
-} from '../api';
-import { expectCellDep, expectTypeId, expectTypeCell, expectCellLock } from './helpers';
+import { bufferToRawString, bytifyRawString, getCellByLock } from '../helpers';
+import { createSpore, transferSpore, meltSpore, getSporeByOutPoint, createCluster, getClusterByOutPoint } from '../api';
+import { expectCellDep, expectTypeId, expectTypeCell, expectCellLock, Account } from './helpers';
 import { getSporeOutput, popRecord, retryQuery, signAndOrSendTransaction, OutPointRecord } from './helpers';
 import { TEST_ACCOUNTS, TEST_ENV, SPORE_OUTPOINT_RECORDS, cleanupRecords } from './shared';
 import { meltThenCreateSpore } from '../api/composed/spore/meltThenCreateSpore';
@@ -20,6 +11,14 @@ import { meltThenCreateSpore } from '../api/composed/spore/meltThenCreateSpore';
 describe('Spore', () => {
   const { rpc, config } = TEST_ENV;
   const { CHARLIE, ALICE } = TEST_ACCOUNTS;
+
+  async function getLiveCell(account: Account): Promise<Cell | undefined> {
+    const indexer = new Indexer(config.ckbIndexerUrl);
+    return getCellByLock({
+      lock: account.lock,
+      indexer,
+    });
+  }
 
   afterAll(async () => {
     await cleanupRecords({
@@ -30,13 +29,15 @@ describe('Spore', () => {
   describe('Spore basics', () => {
     let existingSporeRecord: OutPointRecord | undefined;
     it('Create a Spore', async () => {
+      const capacityCell = await getLiveCell(CHARLIE);
       const { txSkeleton, outputIndex, reference } = await createSpore({
         data: {
           contentType: 'text/plain',
           content: bytifyRawString('content'),
         },
         toLock: CHARLIE.lock,
-        fromInfos: [CHARLIE.address],
+        fromInfos: [],
+        fromCells: [capacityCell!],
         config,
       });
 
@@ -307,17 +308,16 @@ describe('Spore', () => {
     }, 60000);
 
     it('Melt and Create a Spore', async () => {
-      console.log('check for spore cell: ', existingSporeRecord);
       expect(existingSporeRecord).toBeDefined();
       const sporeRecord = existingSporeRecord!;
       const sporeCell = await retryQuery(() => getSporeByOutPoint(sporeRecord.outPoint, config));
 
-      console.log('check for cluster cell: ', existingClusterRecord);
       expect(existingClusterRecord).toBeDefined();
       const clusterRecord = existingClusterRecord!;
       const clusterCell = await retryQuery(() => getClusterByOutPoint(clusterRecord.outPoint, config));
       const clusterId = clusterCell.cellOutput.type!.args;
 
+      const capacityCell = await getLiveCell(CHARLIE);
       const { txSkeleton, outputIndex } = await meltThenCreateSpore({
         data: {
           contentType: 'text/plain',
@@ -325,7 +325,8 @@ describe('Spore', () => {
           clusterId,
         },
         toLock: CHARLIE.lock,
-        fromInfos: [CHARLIE.address],
+        fromInfos: [],
+        fromCells: [capacityCell!],
         outPoint: sporeCell.outPoint!,
         changeAddress: CHARLIE.address,
         config,

--- a/packages/core/src/__tests__/shared/env.ts
+++ b/packages/core/src/__tests__/shared/env.ts
@@ -20,6 +20,11 @@ export const TEST_VARIABLES = {
       'string',
       '0x49aa6d595ac46cc8e1a31b511754dd58f241a7d8a6ad29e83d6b0c1a82399f3d',
     ),
+    bob: getEnvVariable(
+      'VITE_ACCOUNT_BOB',
+      'string',
+      '0xee638e49a61bdc7fda63c412c29d5185eec2913f1122ab59b5d362ee9ef9bb50',
+    ),
   },
 };
 
@@ -36,4 +41,5 @@ export const TEST_ENV = {
 export const TEST_ACCOUNTS = {
   CHARLIE: createDefaultLockAccount(TEST_VARIABLES.accounts.charlie, config),
   ALICE: createDefaultLockAccount(TEST_VARIABLES.accounts.alice, config),
+  BOB: createDefaultLockAccount(TEST_VARIABLES.accounts.bob, config),
 };

--- a/packages/core/src/api/composed/spore/createSpore.ts
+++ b/packages/core/src/api/composed/spore/createSpore.ts
@@ -140,3 +140,137 @@ export async function createSpore(props: {
     mutantReference: injectNewSporeResult.mutantReference,
   };
 }
+
+export async function createMultipleSpores(props: {
+  sporeInfos: {
+    data: SporeDataProps;
+    toLock: Script;
+  }[];
+  fromInfos: FromInfo[];
+  fromCells?: Cell[];
+  changeAddress?: Address;
+  updateOutput?: (cell: Cell) => Cell;
+  capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
+  cluster?: {
+    updateOutput?: (cell: Cell) => Cell;
+    capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
+    updateWitness?: HexString | ((witness: HexString) => HexString);
+  };
+  clusterAgentOutPoint?: OutPoint;
+  clusterAgent?: {
+    updateOutput?: (cell: Cell) => Cell;
+    capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
+    updateWitness?: HexString | ((witness: HexString) => HexString);
+  };
+  mutant?: {
+    paymentAmount?: (minPayment: BI, lock: Script, cell: Cell) => BIish;
+  };
+  maxTransactionSize?: number | false;
+  config?: SporeConfig;
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  outputIndices: number[];
+}> {
+  // Env
+  const config = props.config ?? getSporeConfig();
+  const indexer = new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl);
+  const capacityMargin = BI.from(props.capacityMargin ?? 1_0000_0000);
+
+  // TransactionSkeleton
+  let txSkeleton = helpers.TransactionSkeleton({
+    cellProvider: indexer,
+  });
+
+  // Insert input cells in advance for particular purpose
+  if (props.fromCells) {
+    txSkeleton.update('inputs', (inputs) => {
+      for (const cell of props.fromCells!) {
+        const address = encodeToAddress(cell.cellOutput.lock, { config: config.lumos });
+        const customScript = {
+          script: cell.cellOutput.lock,
+          customData: cell.data,
+        };
+        if (props.fromInfos.indexOf(address) < 0 && props.fromInfos.indexOf(customScript) < 0) {
+          props.fromInfos.push(address);
+        }
+        inputs.push(cell);
+      }
+      return inputs;
+    });
+  }
+
+  // If referencing a ClusterAgent, get it from the OutPoint
+  let clusterAgentCell: Cell | undefined;
+  if (props.clusterAgentOutPoint) {
+    clusterAgentCell = await getClusterAgentByOutPoint(props.clusterAgentOutPoint, config);
+  }
+
+  // Create and inject Spores to Transaction.outputs
+  const injectNewSporeResults: Awaited<ReturnType<typeof injectNewSporeOutput>>[] = [];
+  for (const sporeInfo of props.sporeInfos) {
+    const result = await injectNewSporeOutput({
+      txSkeleton,
+      data: sporeInfo.data,
+      toLock: sporeInfo.toLock,
+      fromInfos: props.fromInfos,
+      changeAddress: props.changeAddress,
+      updateOutput: props.updateOutput,
+      clusterAgent: props.clusterAgent,
+      cluster: props.cluster,
+      mutant: props.mutant,
+      clusterAgentCell,
+      capacityMargin,
+      config,
+    });
+
+    txSkeleton = result.txSkeleton;
+    injectNewSporeResults.push(result);
+  }
+
+  // Inject needed capacity and pay fee
+  const sporeOutputIndices = injectNewSporeResults.map((r) => r.outputIndex);
+  const injectCapacityAndPayFeeResult = await injectCapacityAndPayFee({
+    txSkeleton,
+    fromInfos: props.fromInfos,
+    changeAddress: props.changeAddress,
+    updateTxSkeletonAfterCollection(_txSkeleton) {
+      // Generate and inject SporeID
+      _txSkeleton = injectNewSporeIds({
+        txSkeleton: _txSkeleton,
+        outputIndices: sporeOutputIndices,
+        config,
+      });
+
+      // Inject CobuildProof
+      const actions = [];
+      for (const injectNewSporeResult of injectNewSporeResults) {
+        const sporeCell = txSkeleton.get('outputs').get(injectNewSporeResult.outputIndex)!;
+        const sporeScript = getSporeScript(config, 'Spore', sporeCell.cellOutput.type!);
+        if (sporeScript.behaviors?.cobuild) {
+          const actionResult = generateCreateSporeAction({
+            txSkeleton: _txSkeleton,
+            reference: injectNewSporeResult.reference,
+            outputIndex: injectNewSporeResult.outputIndex,
+          });
+          actions.push(...actionResult.actions);
+        }
+      }
+      if (actions.length) {
+        const injectCobuildProofResult = injectCommonCobuildProof({
+          txSkeleton: _txSkeleton,
+          actions,
+        });
+        _txSkeleton = injectCobuildProofResult.txSkeleton;
+      }
+
+      return _txSkeleton;
+    },
+    config,
+  });
+  txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;
+
+  return {
+    txSkeleton,
+    outputIndices: sporeOutputIndices,
+  };
+}

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_TESTS_CLUSTER_V1: string;
   readonly VITE_ACCOUNT_CHARLIE: string;
   readonly VITE_ACCOUNT_ALICE: string;
+  readonly VITE_ACCOUNT_BOB: string;
 }
 
 interface ImportMeta {

--- a/packages/core/src/helpers/cell.ts
+++ b/packages/core/src/helpers/cell.ts
@@ -7,6 +7,18 @@ import { CKBComponents } from '@ckb-lumos/rpc/lib/types/api';
 import { ScriptId } from '../codec';
 import { isScriptValueEquals } from './script';
 
+export async function getCellByLock(props: { lock: Script; indexer: Indexer }) {
+  const collector = props.indexer.collector({
+    lock: props.lock,
+  });
+
+  for await (const cell of collector.collect()) {
+    return cell;
+  }
+
+  return void 0;
+}
+
 /**
  * Find and return the first cell of target type script from CKB Indexer.
  */


### PR DESCRIPTION
# Description
Unicorn team demands increasing concurrency ability of creating Spore cells from particular Cluster, and the best solution is to inject scattered capacity cells to open `cluster-lock-proxy` mode, which allows our SDK to support arbitrary cells put in skeleton's `inputs` part.

By the way, `createMultipleSpores` interface is already indicated in branch `test/bulk-actions`, so I just moved changes from it to my PR, for the emergency demand from JoyID team.