### PR TITLE
chore: add feerate

### DIFF
--- a/.changeset/shaggy-snakes-collect.md
+++ b/.changeset/shaggy-snakes-collect.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+add `feerate` parameter to all of interfaces

--- a/packages/core/src/api/composed/cluster/createCluster.ts
+++ b/packages/core/src/api/composed/cluster/createCluster.ts
@@ -17,6 +17,7 @@ export async function createCluster(props: {
   updateOutput?: (cell: Cell) => Cell;
   capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
   maxTransactionSize?: number | false;
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -49,6 +50,7 @@ export async function createCluster(props: {
     txSkeleton,
     fromInfos: props.fromInfos,
     changeAddress: props.changeAddress,
+    feeRate: props.feeRate,
     updateTxSkeletonAfterCollection(_txSkeleton) {
       // Generate ID for the new Cluster (if possible)
       _txSkeleton = injectNewClusterIds({

--- a/packages/core/src/api/composed/cluster/transferCluster.ts
+++ b/packages/core/src/api/composed/cluster/transferCluster.ts
@@ -18,6 +18,7 @@ export async function transferCluster(props: {
   updateWitness?: HexString | ((witness: HexString) => HexString);
   defaultWitness?: HexString;
   since?: PackedSince;
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -79,6 +80,7 @@ export async function transferCluster(props: {
       txSkeleton,
       fromInfos: props.fromInfos!,
       changeAddress: props.changeAddress,
+      feeRate: props.feeRate,
       updateTxSkeletonAfterCollection(_txSkeleton) {
         // Inject CobuildProof
         if (clusterScript.behaviors?.cobuild) {

--- a/packages/core/src/api/composed/clusterAgent/createClusterAgent.ts
+++ b/packages/core/src/api/composed/clusterAgent/createClusterAgent.ts
@@ -22,6 +22,7 @@ export async function createClusterAgent(props: {
     capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
     updateWitness?: HexString | ((witness: HexString) => HexString);
   };
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -63,6 +64,7 @@ export async function createClusterAgent(props: {
     txSkeleton,
     fromInfos: props.fromInfos,
     changeAddress: props.changeAddress,
+    feeRate: props.feeRate,
     updateTxSkeletonAfterCollection(_txSkeleton) {
       // Inject CobuildProof
       const clusterAgentCell = txSkeleton.get('outputs').get(injectNewClusterAgentOutputResult.outputIndex)!;

--- a/packages/core/src/api/composed/clusterAgent/transferClusterAgent.ts
+++ b/packages/core/src/api/composed/clusterAgent/transferClusterAgent.ts
@@ -18,6 +18,7 @@ export async function transferClusterAgent(props: {
   updateWitness?: HexString | ((witness: HexString) => HexString);
   defaultWitness?: HexString;
   since?: PackedSince;
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -79,6 +80,7 @@ export async function transferClusterAgent(props: {
       txSkeleton,
       fromInfos: props.fromInfos!,
       changeAddress: props.changeAddress,
+      feeRate: props.feeRate,
       updateTxSkeletonAfterCollection(_txSkeleton) {
         // Inject CobuildProof
         if (clusterAgentScript.behaviors?.cobuild) {

--- a/packages/core/src/api/composed/clusterProxy/createClusterProxy.ts
+++ b/packages/core/src/api/composed/clusterProxy/createClusterProxy.ts
@@ -20,6 +20,7 @@ export async function createClusterProxy(props: {
     capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
     updateWitness?: HexString | ((witness: HexString) => HexString);
   };
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -60,6 +61,7 @@ export async function createClusterProxy(props: {
     txSkeleton,
     fromInfos: props.fromInfos,
     changeAddress: props.changeAddress,
+    feeRate: props.feeRate,
     updateTxSkeletonAfterCollection(_txSkeleton) {
       // Generate and inject ID for the new ClusterProxy
       _txSkeleton = injectNewClusterProxyIds({

--- a/packages/core/src/api/composed/clusterProxy/transferClusterProxy.ts
+++ b/packages/core/src/api/composed/clusterProxy/transferClusterProxy.ts
@@ -19,6 +19,7 @@ export async function transferClusterProxy(props: {
   updateWitness?: HexString | ((witness: HexString) => HexString);
   defaultWitness?: HexString;
   since?: PackedSince;
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -80,6 +81,7 @@ export async function transferClusterProxy(props: {
       txSkeleton,
       fromInfos: props.fromInfos!,
       changeAddress: props.changeAddress,
+      feeRate: props.feeRate,
       updateTxSkeletonAfterCollection(_txSkeleton) {
         // Inject CobuildProof
         if (clusterProxyScript.behaviors?.cobuild) {

--- a/packages/core/src/api/composed/mutant/createMutant.ts
+++ b/packages/core/src/api/composed/mutant/createMutant.ts
@@ -16,6 +16,7 @@ export async function createMutant(props: {
   updateOutput?(cell: Cell): Cell;
   capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
   maxTransactionSize?: number | false;
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -49,6 +50,7 @@ export async function createMutant(props: {
     txSkeleton,
     fromInfos: props.fromInfos,
     changeAddress: props.changeAddress,
+    feeRate: props.feeRate,
     config,
   });
   txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;

--- a/packages/core/src/api/composed/mutant/transferMutant.ts
+++ b/packages/core/src/api/composed/mutant/transferMutant.ts
@@ -18,6 +18,7 @@ export async function transferMutant(props: {
   updateWitness?: HexString | ((witness: HexString) => HexString);
   defaultWitness?: HexString;
   since?: PackedSince;
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -72,6 +73,7 @@ export async function transferMutant(props: {
       txSkeleton,
       changeAddress: props.changeAddress,
       fromInfos: props.fromInfos!,
+      feeRate: props.feeRate,
       config,
     });
     txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;

--- a/packages/core/src/api/composed/spore/createSpore.ts
+++ b/packages/core/src/api/composed/spore/createSpore.ts
@@ -35,6 +35,7 @@ export async function createSpore(props: {
     paymentAmount?: (minPayment: BI, lock: Script, cell: Cell) => BIish;
   };
   maxTransactionSize?: number | false;
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -112,6 +113,7 @@ export async function createSpore(props: {
     txSkeleton,
     fromInfos: props.fromInfos,
     changeAddress: props.changeAddress,
+    feeRate: props.feeRate,
     updateTxSkeletonAfterCollection(_txSkeleton) {
       // Generate and inject SporeID
       _txSkeleton = injectNewSporeIds({

--- a/packages/core/src/api/composed/spore/transferSpore.ts
+++ b/packages/core/src/api/composed/spore/transferSpore.ts
@@ -18,6 +18,7 @@ export async function transferSpore(props: {
   updateWitness?: HexString | ((witness: HexString) => HexString);
   defaultWitness?: HexString;
   since?: PackedSince;
+  feeRate?: BIish | undefined;
   config?: SporeConfig;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
@@ -77,6 +78,7 @@ export async function transferSpore(props: {
       txSkeleton,
       fromInfos: props.fromInfos!,
       changeAddress: props.changeAddress,
+      feeRate: props.feeRate,
       updateTxSkeletonAfterCollection(_txSkeleton) {
         // Inject CobuildProof
         if (sporeScript.behaviors?.cobuild) {


### PR DESCRIPTION
# Description
add `feerate` parameter to all of interfaces, because insufficient feerate error encountered if only using the suggested feerate through node url.