### PR TITLE
chore: bump version 0.2.0-beta.7

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -18,6 +18,7 @@
     "pretty-lobsters-count",
     "proud-phones-camp",
     "rare-coins-notice",
+    "shaggy-snakes-collect",
     "slimy-peas-share",
     "slow-tools-flow",
     "small-lobsters-jam",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spore-sdk/core
 
+## 0.2.0-beta.7
+
+### Patch Changes
+
+- a34515c: add `feerate` parameter to all of interfaces
+
 ## 0.2.0-beta.6
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spore-sdk/core",
-  "version": "0.2.0-beta.6",
+  "version": "0.2.0-beta.7",
   "license": "MIT",
   "scripts": {
     "test": "vitest",


### PR DESCRIPTION
# Description
bump version to `0.2.0-beta.7`