### PR TITLE
chore: skip checking content-type

### DIFF
--- a/.changeset/spotty-islands-sort.md
+++ b/.changeset/spotty-islands-sort.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': minor
+---
+
+export co-build interfaces and able to skip checking content-type

--- a/packages/core/src/api/joints/spore/injectLiveSporeCell.ts
+++ b/packages/core/src/api/joints/spore/injectLiveSporeCell.ts
@@ -1,7 +1,7 @@
 import { BIish } from '@ckb-lumos/bi';
 import { PackedSince } from '@ckb-lumos/base';
 import { BI, Cell, helpers, HexString } from '@ckb-lumos/lumos';
-import { addCellDep } from '@ckb-lumos/lumos/helpers';
+import { addCellDep, parseAddress } from '@ckb-lumos/lumos/helpers';
 import { decodeContentType, isContentTypeValid, setAbsoluteCapacityMargin, setupCell } from '../../../helpers';
 import { getSporeConfig, getSporeScript, SporeConfig } from '../../../config';
 import { unpackToRawSporeData } from '../../../codec';
@@ -15,6 +15,7 @@ export async function injectLiveSporeCell(props: {
   capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
   updateWitness?: HexString | ((witness: HexString) => HexString);
   defaultWitness?: HexString;
+  skipCheckContentType?: boolean;
   since?: PackedSince;
   config?: SporeConfig;
 }): Promise<{
@@ -72,7 +73,8 @@ export async function injectLiveSporeCell(props: {
 
   // Validate SporeData.contentType
   const sporeData = unpackToRawSporeData(sporeCell.data);
-  if (!isContentTypeValid(sporeData.contentType)) {
+  const skipCheckContentType = props.skipCheckContentType ?? false;
+  if (!skipCheckContentType && !isContentTypeValid(sporeData.contentType)) {
     throw new Error(`Spore has specified invalid ContentType: ${sporeData.contentType}`);
   }
 

--- a/packages/core/src/api/joints/spore/injectLiveSporeCell.ts
+++ b/packages/core/src/api/joints/spore/injectLiveSporeCell.ts
@@ -15,7 +15,6 @@ export async function injectLiveSporeCell(props: {
   capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
   updateWitness?: HexString | ((witness: HexString) => HexString);
   defaultWitness?: HexString;
-  skipCheckContentType?: boolean;
   since?: PackedSince;
   config?: SporeConfig;
 }): Promise<{
@@ -73,10 +72,10 @@ export async function injectLiveSporeCell(props: {
 
   // Validate SporeData.contentType
   const sporeData = unpackToRawSporeData(sporeCell.data);
-  const skipCheckContentType = props.skipCheckContentType ?? false;
-  if (!skipCheckContentType && !isContentTypeValid(sporeData.contentType)) {
-    throw new Error(`Spore has specified invalid ContentType: ${sporeData.contentType}`);
-  }
+  // note: consider the compatibility of custom spore-like scripts, skip content-type check is allowed
+  // if (!isContentTypeValid(sporeData.contentType)) {
+  //   throw new Error(`Spore has specified invalid ContentType: ${sporeData.contentType}`);
+  // }
 
   // Add Mutant cells as cellDeps
   const decodedContentType = decodeContentType(sporeData.contentType);

--- a/packages/core/src/api/joints/spore/injectNewSporeOutput.ts
+++ b/packages/core/src/api/joints/spore/injectNewSporeOutput.ts
@@ -46,6 +46,7 @@ export async function injectNewSporeOutput(props: {
     defaultWitness?: HexString;
     since?: PackedSince;
   };
+  skipCheckContentType?: boolean;
   mutant?: {
     paymentAmount?: (minPayment: BI, lock: Script, cell: Cell) => BIish;
   };
@@ -151,7 +152,8 @@ export async function injectNewSporeOutput(props: {
 
   // Validate SporeData.contentType
   const contentType = setContentTypeParameters(sporeData.contentType, sporeData.contentTypeParameters ?? {});
-  if (!isContentTypeValid(contentType)) {
+  const skipCheckContentType = props.skipCheckContentType ?? false;
+  if (!skipCheckContentType && !isContentTypeValid(contentType)) {
     throw new Error(`Spore has specified an invalid data.contentType: ${contentType}`);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from './codec';
 export * from './config';
 export * from './helpers';
 export * from './api';
+export * from './cobuild';


### PR DESCRIPTION
# Description
considering we may have developers who make their own custom spore-like contracts that also building applications under spore-sdk, it's proper to enable to skip the check of content-type limitation.

co-build feature is essential for current version of spore contract, exporting its interfaces directly is reasonable.