### PR TITLE
feat: adds `transferMultipleSpore` and `meltMultipleThenCreateSpore`

### DIFF
--- a/packages/core/src/__tests__/Multiple.test.ts
+++ b/packages/core/src/__tests__/Multiple.test.ts
@@ -52,7 +52,7 @@ describe('Multiple', options, () => {
     // dirty but works
     await new Promise((f) => setTimeout(f, 20000));
     const spore_cells = MultipleTestSPORE_OUTPOINT_RECORDS.map((spore) => spore.outPoint);
-    const txSkeleton = await transferMultipleSpore({
+    const { txSkeleton, inputIndecies, outputIndecies } = await transferMultipleSpore({
       outPoints: spore_cells,
       fromInfos: [CHARLIE.address],
       toLock: ALICE.lock,

--- a/packages/core/src/__tests__/Multiple.test.ts
+++ b/packages/core/src/__tests__/Multiple.test.ts
@@ -1,0 +1,94 @@
+import { BI } from '@ckb-lumos/lumos';
+import { describe, it } from 'vitest';
+import { createMultipleSpores, getSporeById, meltMultipleThenCreateSpore, transferMultipleSpore } from '../api';
+import { predefinedSporeConfigs } from '../config';
+import { bytifyRawString } from '../helpers';
+import { signAndOrSendTransaction } from './helpers';
+import { MultipleTestSPORE_OUTPOINT_RECORDS, TEST_ACCOUNTS, TEST_ENV } from './shared';
+
+const options = {
+  timeout: 10000000,
+};
+describe('Multiple', options, () => {
+  const { rpc, config } = TEST_ENV;
+  const { ALICE, BOB, CHARLIE } = TEST_ACCOUNTS;
+
+  it('Create Multiple First', async () => {
+    const createAmount = 2;
+    const { txSkeleton, outputIndices } = await createMultipleSpores({
+      sporeInfos: Array(createAmount).fill({
+        data: {
+          contentType: 'text/plain',
+          content: bytifyRawString('content'),
+        },
+        toLock: CHARLIE.lock,
+      }),
+      fromInfos: [CHARLIE.address],
+      config,
+    });
+    const { hash } = await signAndOrSendTransaction({
+      account: CHARLIE,
+      txSkeleton,
+      config,
+      rpc,
+      send: true,
+    });
+
+    if (hash) {
+      for (const index of outputIndices) {
+        MultipleTestSPORE_OUTPOINT_RECORDS.push({
+          outPoint: {
+            txHash: hash,
+            index: BI.from(index).toHexString(),
+          },
+          account: CHARLIE,
+          sporeId: txSkeleton.get('outputs').get(index)!.cellOutput.type!.args,
+        });
+      }
+    }
+  });
+  it('Multiple Transfer', async () => {
+    // wait for transaction success
+    // dirty but works
+    await new Promise((f) => setTimeout(f, 20000));
+    const spore_cells = MultipleTestSPORE_OUTPOINT_RECORDS.map((spore) => spore.outPoint);
+    const txSkeleton = await transferMultipleSpore({
+      outPoints: spore_cells,
+      fromInfos: [CHARLIE.address],
+      toLock: ALICE.lock,
+      config: predefinedSporeConfigs.Testnet,
+    });
+
+    const hash = await signAndOrSendTransaction({ account: CHARLIE, txSkeleton, config, rpc, send: true });
+    console.log(`Spore Multiple Transfer at: https://pudge.explorer.nervos.org/transaction/${hash.hash}`);
+    //console.log(`Spore ID: ${txSkeleton.get('outputs').get(outputIndex)!.cellOutput.type!.args}`);
+  }),
+    it('Multiple Melt Then Create One', async () => {
+      // wait for transaction success
+      // dirty but works
+      await new Promise((f) => setTimeout(f, 20000));
+      const sporeIds = MultipleTestSPORE_OUTPOINT_RECORDS.map((spore) => spore.sporeId);
+      const sporeCells = (
+        await Promise.all(
+          sporeIds.map(async (spore_id) => {
+            const sporeData = await getSporeById(spore_id, predefinedSporeConfigs.Testnet);
+            return sporeData?.outPoint;
+          }),
+        )
+      ).filter((outPoint) => outPoint !== undefined);
+
+      const { txSkeleton } = await meltMultipleThenCreateSpore({
+        outPoints: sporeCells,
+        fromInfos: [ALICE.address],
+        toLock: BOB.lock,
+        config: predefinedSporeConfigs.Testnet,
+        data: {
+          contentType: 'text/plain',
+          content: bytifyRawString('content'),
+        },
+      });
+      const hash = await signAndOrSendTransaction({ account: ALICE, txSkeleton, config, rpc, send: true });
+      console.log(`Spore created at: https://pudge.explorer.nervos.org/transaction/${hash.hash}`);
+      //console.log(`Spore ID: ${txSkeleton.get('outputs').get(outputIndex)!.cellOutput.type!.args}`);
+    });
+});

--- a/packages/core/src/__tests__/helpers/index.ts
+++ b/packages/core/src/__tests__/helpers/index.ts
@@ -4,3 +4,4 @@ export * from './check';
 export * from './retry';
 export * from './file';
 export * from './config';
+export * from './wallet';

--- a/packages/core/src/__tests__/helpers/wallet.ts
+++ b/packages/core/src/__tests__/helpers/wallet.ts
@@ -1,0 +1,92 @@
+import { defaultEmptyWitnessArgs, updateWitnessArgs, isScriptValueEquals, getSporeConfig } from '../..';
+import { hd, helpers, RPC, Address, Hash, Script, HexString } from '@ckb-lumos/lumos';
+import { secp256k1Blake160 } from '@ckb-lumos/lumos/common-scripts';
+
+export interface Wallet {
+  lock: Script;
+  address: Address;
+  signMessage(message: HexString): Hash;
+  signTransaction(txSkeleton: helpers.TransactionSkeletonType): helpers.TransactionSkeletonType;
+  signAndSendTransaction(txSkeleton: helpers.TransactionSkeletonType): Promise<Hash>;
+}
+
+/**
+ * Create a CKB Default Lock (Secp256k1Blake160 Sign-all) Wallet by a private-key and a SporeConfig,
+ * providing lock/address, and functions to sign message/transaction and send the transaction on-chain.
+ */
+export function createDefaultLockWallet(privateKey: HexString): Wallet {
+  const config = getSporeConfig();
+
+  // Generate a lock script from the private key
+  const defaultLock = config.lumos.SCRIPTS.SECP256K1_BLAKE160!;
+  const lock: Script = {
+    codeHash: defaultLock.CODE_HASH,
+    hashType: defaultLock.HASH_TYPE,
+    args: hd.key.privateKeyToBlake160(privateKey),
+  };
+
+  // Generate address from the lock script
+  const address = helpers.encodeToAddress(lock, {
+    config: config.lumos,
+  });
+
+  // Sign for a message
+  function signMessage(message: HexString): Hash {
+    return hd.key.signRecoverable(message, privateKey);
+  }
+
+  // Sign prepared signing entries,
+  // and then fill signatures into Transaction.witnesses
+  function signTransaction(txSkeleton: helpers.TransactionSkeletonType): helpers.TransactionSkeletonType {
+    const signingEntries = txSkeleton.get('signingEntries');
+    const signatures = new Map<HexString, Hash>();
+    const inputs = txSkeleton.get('inputs');
+
+    let witnesses = txSkeleton.get('witnesses');
+    for (let i = 0; i < signingEntries.size; i++) {
+      const entry = signingEntries.get(i)!;
+      if (entry.type === 'witness_args_lock') {
+        // Skip if the input's lock does not match to the wallet's lock
+        const input = inputs.get(entry.index);
+        if (!input || !isScriptValueEquals(input.cellOutput.lock, lock)) {
+          continue;
+        }
+
+        // Sign message
+        if (!signatures.has(entry.message)) {
+          const sig = signMessage(entry.message);
+          signatures.set(entry.message, sig);
+        }
+
+        // Update signature to Transaction.witnesses
+        const signature = signatures.get(entry.message)!;
+        const witness = witnesses.get(entry.index, defaultEmptyWitnessArgs);
+        witnesses = witnesses.set(entry.index, updateWitnessArgs(witness, 'lock', signature));
+      }
+    }
+
+    return txSkeleton.set('witnesses', witnesses);
+  }
+
+  // Sign the transaction and send it via RPC
+  async function signAndSendTransaction(txSkeleton: helpers.TransactionSkeletonType): Promise<Hash> {
+    // 1. Sign transaction
+    txSkeleton = secp256k1Blake160.prepareSigningEntries(txSkeleton, { config: config.lumos });
+    txSkeleton = signTransaction(txSkeleton);
+
+    // 2. Convert TransactionSkeleton to Transaction
+    const tx = helpers.createTransactionFromSkeleton(txSkeleton);
+
+    // 3. Send transaction
+    const rpc = new RPC(config.ckbNodeUrl);
+    return await rpc.sendTransaction(tx, 'passthrough');
+  }
+
+  return {
+    lock,
+    address,
+    signMessage,
+    signTransaction,
+    signAndSendTransaction,
+  };
+}

--- a/packages/core/src/__tests__/shared/record.ts
+++ b/packages/core/src/__tests__/shared/record.ts
@@ -11,6 +11,12 @@ export const CLUSTER_OUTPOINT_RECORDS: OutPointRecord[] = [];
 export const CLUSTER_PROXY_OUTPOINT_RECORDS: OutPointRecord[] = [];
 export const CLUSTER_AGENT_OUTPOINT_RECORDS: OutPointRecord[] = [];
 
+export interface OutpointWithSporeIdRecord extends OutPointRecord {
+  sporeId: string;
+}
+
+export const MultipleTestSPORE_OUTPOINT_RECORDS: OutpointWithSporeIdRecord[] = [];
+
 export async function cleanupRecords(props: { name: string }) {
   const [sporeCleanupResults, clusterProxyCleanupResults, clusterAgentCleanupResults] = await Promise.all([
     cleanupSporeRecords(),

--- a/packages/core/src/api/composed/spore/meltThenCreateSpore.ts
+++ b/packages/core/src/api/composed/spore/meltThenCreateSpore.ts
@@ -1,21 +1,29 @@
 import { Address, OutPoint, PackedSince, Script } from '@ckb-lumos/base';
-import { BI, BIish, Cell, helpers, HexString, Indexer } from '@ckb-lumos/lumos';
 import { FromInfo } from '@ckb-lumos/common-scripts';
-import { SporeDataProps, injectNewSporeOutput, injectNewSporeIds, getClusterAgentByOutPoint } from '../..';
-import { getSporeByOutPoint, injectLiveSporeCell } from '../..';
-import { getSporeConfig, getSporeScript, SporeConfig } from '../../../config';
+import { BI, BIish, Cell, helpers, HexString, Indexer } from '@ckb-lumos/lumos';
+import { encodeToAddress, TransactionSkeletonType } from '@ckb-lumos/lumos/helpers';
+import { parseUnit } from '@ckb-lumos/lumos/utils';
+import {
+  getClusterAgentByOutPoint,
+  getSporeByOutPoint,
+  injectLiveSporeCell,
+  injectNewSporeIds,
+  injectNewSporeOutput,
+  SporeDataProps,
+} from '../..';
 import { generateCreateSporeAction, generateMeltSporeAction, injectCommonCobuildProof } from '../../../cobuild';
+import { getSporeConfig, getSporeScript, SporeConfig } from '../../../config';
 import {
   assertTransactionSkeletonSize,
   createCapacitySnapshotFromTransactionSkeleton,
+  getMinFeeRate,
   injectCapacityAndPayFee,
   returnExceededCapacityAndPayFee,
   setupCell,
 } from '../../../helpers';
-import { TransactionSkeletonType, encodeToAddress } from '@ckb-lumos/lumos/helpers';
 
 function InjectCobuildForMeltThenCreateSpore(
-  meltSporeInputIndex: number,
+  meltSporeInputIndexs: number[],
   mintSporeCell: Cell,
   mintSporeReference: Awaited<ReturnType<typeof injectNewSporeOutput>>['reference'],
   mintSporeOutputIndex: number,
@@ -24,16 +32,17 @@ function InjectCobuildForMeltThenCreateSpore(
 ): TransactionSkeletonType {
   const sporeScript = getSporeScript(config, 'Spore', mintSporeCell.cellOutput.type!);
   if (sporeScript.behaviors?.cobuild) {
-    const meltActionResult = generateMeltSporeAction({
-      txSkeleton,
-      inputIndex: meltSporeInputIndex,
-    });
+    const actions = [];
+    for (const meltIndex of meltSporeInputIndexs) {
+      const meltActionResults = generateMeltSporeAction({ txSkeleton, inputIndex: meltIndex });
+      actions.push(...meltActionResults.actions);
+    }
     const mintActionResult = generateCreateSporeAction({
       txSkeleton,
       reference: mintSporeReference,
       outputIndex: mintSporeOutputIndex,
     });
-    const actions = meltActionResult.actions.concat(mintActionResult.actions);
+    actions.push(...mintActionResult.actions);
     const injectCobuildProofResult = injectCommonCobuildProof({
       txSkeleton,
       actions,
@@ -219,7 +228,7 @@ export async function meltThenCreateSpore(props: {
     });
     const mintSporeCell = txSkeleton.get('outputs').get(injectNewSporeResult.outputIndex)!;
     txSkeleton = InjectCobuildForMeltThenCreateSpore(
-      injectLiveSporeCellResult.inputIndex,
+      [injectLiveSporeCellResult.inputIndex],
       mintSporeCell,
       injectNewSporeResult.reference,
       injectNewSporeResult.outputIndex,
@@ -261,7 +270,7 @@ export async function meltThenCreateSpore(props: {
 
         const mintSporeCell = txSkeleton.get('outputs').get(injectNewSporeResult.outputIndex)!;
         _txSkeleton = InjectCobuildForMeltThenCreateSpore(
-          injectLiveSporeCellResult.inputIndex,
+          [injectLiveSporeCellResult.inputIndex],
           mintSporeCell,
           injectNewSporeResult.reference,
           injectNewSporeResult.outputIndex,
@@ -283,6 +292,264 @@ export async function meltThenCreateSpore(props: {
   return {
     txSkeleton,
     inputIndex: injectLiveSporeCellResult.inputIndex,
+    outputIndex: injectNewSporeResult.outputIndex,
+    reference: injectNewSporeResult.reference,
+    mutantReference: injectNewSporeResult.mutantReference,
+  };
+}
+
+export async function meltMultipleThenCreateSpore(props: {
+  outPoints: OutPoint[];
+  changeAddress?: Address;
+  updateWitness?: HexString | ((witness: HexString) => HexString);
+  defaultWitness?: HexString;
+  since?: PackedSince;
+  config?: SporeConfig;
+  data: SporeDataProps;
+  toLock: Script;
+  fromInfos: FromInfo[];
+  prefixInputs?: Cell[];
+  prefixOutputs?: Cell[];
+  postInputs?: Cell[];
+  postOutputs?: Cell[];
+  feeRate?: BIish | undefined;
+  updateOutput?: (cell: Cell) => Cell;
+  capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
+  cluster?: {
+    updateOutput?: (cell: Cell) => Cell;
+    capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
+    updateWitness?: HexString | ((witness: HexString) => HexString);
+  };
+  clusterAgentOutPoint?: OutPoint;
+  clusterAgent?: {
+    updateOutput?: (cell: Cell) => Cell;
+    capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
+    updateWitness?: HexString | ((witness: HexString) => HexString);
+  };
+  mutant?: {
+    paymentAmount?: (minPayment: BI, lock: Script, cell: Cell) => BIish;
+  };
+  maxTransactionSize?: number | false;
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndexs: number[];
+  outputIndex: number;
+  reference: Awaited<ReturnType<typeof injectNewSporeOutput>>['reference'];
+  mutantReference: Awaited<ReturnType<typeof injectNewSporeOutput>>['mutantReference'];
+}> {
+  /**
+   * Melt Spore with Spore Outputpoint
+   */
+
+  // Env
+  const config = props.config ?? getSporeConfig();
+  const indexer = new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl);
+  const capacityMargin = BI.from(props.capacityMargin ?? 1_0000_0000);
+  const maxTransactionSize = props.maxTransactionSize ?? config.maxTransactionSize ?? false;
+
+  // MeltTransactionSkeleton
+  let txSkeleton = helpers.TransactionSkeleton({
+    cellProvider: indexer,
+  });
+
+  // Insert input cells in advance for particular purpose
+  if (props.prefixInputs) {
+    for (const cell of props.prefixInputs!) {
+      const address = encodeToAddress(cell.cellOutput.lock, { config: config.lumos });
+      const customScript = {
+        script: cell.cellOutput.lock,
+        customData: cell.data,
+      };
+      if (props.fromInfos.indexOf(address) < 0 && props.fromInfos.indexOf(customScript) < 0) {
+        props.fromInfos.push(address);
+      }
+      const setupCellResult = await setupCell({
+        txSkeleton,
+        input: cell,
+        updateWitness: props.updateWitness,
+        defaultWitness: props.defaultWitness,
+        config: config.lumos,
+      });
+      txSkeleton = setupCellResult.txSkeleton;
+    }
+  }
+
+  // Insert output cells in advance for particular purpose
+  if (props.prefixOutputs) {
+    txSkeleton = txSkeleton.update('outputs', (outputs) => {
+      props.prefixOutputs!.forEach((cell) => (outputs = outputs.push(cell)));
+      return outputs;
+    });
+  }
+
+  // Apply `fromInfos` in advance if `postInputs` is provided
+  if (props.postInputs) {
+    for (const cell of props.postInputs!) {
+      const address = encodeToAddress(cell.cellOutput.lock, { config: config.lumos });
+      const customScript = {
+        script: cell.cellOutput.lock,
+        customData: cell.data,
+      };
+      if (props.fromInfos.indexOf(address) < 0 && props.fromInfos.indexOf(customScript) < 0) {
+        props.fromInfos.push(address);
+      }
+    }
+  }
+
+  // Inject live spore to Transaction.inputs
+  let injectLiveSporeCellResults: {
+    txSkeleton: helpers.TransactionSkeletonType;
+    inputIndex: number;
+    outputIndex: number;
+  }[] = [];
+  for (const outPoint of props.outPoints) {
+    const meltSporeCell = await getSporeByOutPoint(outPoint, config);
+    const injectLiveSporeCellResult = await injectLiveSporeCell({
+      txSkeleton,
+      cell: meltSporeCell,
+      updateWitness: props.updateWitness,
+      defaultWitness: props.defaultWitness,
+      since: props.since,
+      config,
+    });
+    injectLiveSporeCellResults.push(injectLiveSporeCellResult);
+    txSkeleton = injectLiveSporeCellResult.txSkeleton;
+  }
+  /**
+   * Create Spore
+   */
+
+  // If referencing a ClusterAgent, get it from the OutPoint
+  let clusterAgentCell: Cell | undefined;
+  if (props.clusterAgentOutPoint) {
+    clusterAgentCell = await getClusterAgentByOutPoint(props.clusterAgentOutPoint, config);
+  }
+
+  const prefixOutputLocks = props.prefixOutputs ? props.prefixOutputs.map((cell) => cell.cellOutput.lock) : [];
+  const postOutputLocks = props.postOutputs ? props.postOutputs.map((cell) => cell.cellOutput.lock) : [];
+  const injectNewSporeResult = await injectNewSporeOutput({
+    txSkeleton,
+    data: props.data,
+    toLock: props.toLock,
+    fromInfos: props.fromInfos,
+    extraOutputLocks: prefixOutputLocks.concat(postOutputLocks),
+    changeAddress: props.changeAddress,
+    updateOutput: props.updateOutput,
+    clusterAgent: props.clusterAgent,
+    cluster: props.cluster,
+    mutant: props.mutant,
+    clusterAgentCell,
+    capacityMargin,
+    config,
+  });
+  txSkeleton = injectNewSporeResult.txSkeleton;
+
+  // Insert input cells in the end for particular purpose
+  if (props.postInputs) {
+    for (const cell of props.postInputs!) {
+      const setupCellResult = await setupCell({
+        txSkeleton,
+        input: cell,
+        updateWitness: props.updateWitness,
+        defaultWitness: props.defaultWitness,
+        config: config.lumos,
+      });
+      txSkeleton = setupCellResult.txSkeleton;
+    }
+  }
+
+  // Insert output cells in the end for particular purpose
+  if (props.postOutputs) {
+    txSkeleton = txSkeleton.update('outputs', (outputs) => {
+      props.postOutputs!.forEach((cell) => (outputs = outputs.push(cell)));
+      return outputs;
+    });
+  }
+
+  /**
+   * check wether Redeem or Inject Capacity and then Pay fee
+   */
+  const snapshot = createCapacitySnapshotFromTransactionSkeleton(txSkeleton);
+  const feeRate = props.feeRate ?? (await getMinFeeRate(config.ckbNodeUrl));
+  if (
+    snapshot.inputsCapacity.gt(snapshot.outputsCapacity) &&
+    snapshot.inputsCapacity.sub(snapshot.outputsCapacity).gt(parseUnit(feeRate.toString(), 'ckb'))
+  ) {
+    /**
+     * Complete Co-Build WitnessLayout
+     */
+    txSkeleton = injectNewSporeIds({
+      outputIndices: [injectNewSporeResult.outputIndex],
+      txSkeleton,
+      config,
+    });
+    const mintSporeCell = txSkeleton.get('outputs').get(injectNewSporeResult.outputIndex)!;
+
+    // Redeem capacity from the exceeded capacity
+    const sporeAddress = helpers.encodeToAddress(mintSporeCell.cellOutput.lock, { config: config.lumos });
+    const returnExceededCapacityAndPayFeeResult = await returnExceededCapacityAndPayFee({
+      txSkeleton,
+      changeAddress: props.changeAddress ?? sporeAddress,
+      feeRate: props.feeRate,
+      fromInfos: props.fromInfos,
+      config,
+    });
+
+    txSkeleton = returnExceededCapacityAndPayFeeResult.txSkeleton;
+    txSkeleton = InjectCobuildForMeltThenCreateSpore(
+      injectLiveSporeCellResults.map((result) => result.inputIndex),
+      mintSporeCell,
+      injectNewSporeResult.reference,
+      injectNewSporeResult.outputIndex,
+      returnExceededCapacityAndPayFeeResult.txSkeleton,
+      config,
+    );
+  } else {
+    /**
+     * Inject Capacity and Pay fee
+     */
+    const injectCapacityAndPayFeeResult = await injectCapacityAndPayFee({
+      txSkeleton,
+      fromInfos: props.fromInfos,
+      changeAddress: props.changeAddress,
+      config,
+      feeRate: props.feeRate,
+      updateTxSkeletonAfterCollection(_txSkeleton) {
+        // Generate and inject SporeID
+        _txSkeleton = injectNewSporeIds({
+          outputIndices: [injectNewSporeResult.outputIndex],
+          txSkeleton: _txSkeleton,
+          config,
+        });
+
+        /**
+         * Complete Co-Build WitnessLayout
+         */
+
+        const mintSporeCell = txSkeleton.get('outputs').get(injectNewSporeResult.outputIndex)!;
+        _txSkeleton = InjectCobuildForMeltThenCreateSpore(
+          injectLiveSporeCellResults.map((result) => result.inputIndex),
+          mintSporeCell,
+          injectNewSporeResult.reference,
+          injectNewSporeResult.outputIndex,
+          _txSkeleton,
+          config,
+        );
+
+        return _txSkeleton;
+      },
+    });
+    txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;
+  }
+
+  // Make sure the tx size is in range (if needed)
+  if (typeof maxTransactionSize === 'number') {
+    assertTransactionSkeletonSize(txSkeleton, void 0, maxTransactionSize);
+  }
+
+  return {
+    txSkeleton,
+    inputIndexs: injectLiveSporeCellResults.map((item) => item.inputIndex),
     outputIndex: injectNewSporeResult.outputIndex,
     reference: injectNewSporeResult.reference,
     mutantReference: injectNewSporeResult.mutantReference,

--- a/packages/core/src/api/composed/spore/transferSpore.ts
+++ b/packages/core/src/api/composed/spore/transferSpore.ts
@@ -1,11 +1,11 @@
-import { BIish } from '@ckb-lumos/bi';
-import { FromInfo } from '@ckb-lumos/lumos/common-scripts';
 import { Address, OutPoint, Script } from '@ckb-lumos/base';
+import { BIish } from '@ckb-lumos/bi';
 import { BI, Cell, helpers, HexString, Indexer, PackedSince } from '@ckb-lumos/lumos';
-import { getSporeConfig, getSporeScript, SporeConfig } from '../../../config';
-import { injectCapacityAndPayFee, payFeeByOutput } from '../../../helpers';
+import { FromInfo } from '@ckb-lumos/lumos/common-scripts';
 import { getSporeByOutPoint, injectLiveSporeCell } from '../..';
 import { generateTransferSporeAction, injectCommonCobuildProof } from '../../../cobuild';
+import { getSporeConfig, getSporeScript, SporeConfig } from '../../../config';
+import { injectCapacityAndPayFee, payFeeByOutput } from '../../../helpers';
 
 export async function transferSpore(props: {
   outPoint: OutPoint;
@@ -117,4 +117,125 @@ export async function transferSpore(props: {
     inputIndex: injectLiveSporeCellResult.inputIndex,
     outputIndex: injectLiveSporeCellResult.outputIndex,
   };
+}
+
+// Transfer multiple Spore at once
+export async function transferMultipleSpore(props: {
+  outPoints: OutPoint[];
+  toLock: Script;
+  fromInfos?: FromInfo[];
+  changeAddress?: Address;
+  useCapacityMarginAsFee?: boolean;
+  updateOutput?: (cell: Cell) => Cell;
+  capacityMargin?: BIish | ((cell: Cell, margin: BI) => BIish);
+  updateWitness?: HexString | ((witness: HexString) => HexString);
+  defaultWitness?: HexString;
+  since?: PackedSince;
+  feeRate?: BIish | undefined;
+  config?: SporeConfig;
+}): Promise<helpers.TransactionSkeletonType> {
+  // Env
+  const config = props.config ?? getSporeConfig();
+  const indexer = new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl);
+  const useCapacityMarginAsFee = props.useCapacityMarginAsFee ?? true;
+
+  // Check capacity margin related props
+  if (!useCapacityMarginAsFee && !props.fromInfos) {
+    throw new Error('When useCapacityMarginAsFee is enabled, fromInfos is also required');
+  }
+  if (useCapacityMarginAsFee && props.capacityMargin !== void 0) {
+    throw new Error('When useCapacityMarginAsFee is enabled, cannot set capacity margin of the spore');
+  }
+
+  // TransactionSkeleton
+  let txSkeleton = helpers.TransactionSkeleton({
+    cellProvider: indexer,
+  });
+  const injectLiveSporeCellResults: Awaited<ReturnType<typeof injectLiveSporeCell>>[] = [];
+
+  // Inject live spore to Transaction.inputs and Transaction.outputs
+  for (const outPoint of props.outPoints) {
+    const sporeCell = await getSporeByOutPoint(outPoint, config);
+    const sporeScript = getSporeScript(config, 'Spore', sporeCell.cellOutput.type!);
+    const injectLiveSporeCellResult = await injectLiveSporeCell({
+      txSkeleton,
+      cell: sporeCell,
+      addOutput: true,
+      updateOutput(cell) {
+        cell.cellOutput.lock = props.toLock;
+        if (props.updateOutput instanceof Function) {
+          cell = props.updateOutput(cell);
+        }
+        return cell;
+      },
+      capacityMargin: props.capacityMargin,
+      defaultWitness: props.defaultWitness,
+      updateWitness: props.updateWitness,
+      since: props.since,
+      config,
+    });
+    txSkeleton = injectLiveSporeCellResult.txSkeleton;
+    injectLiveSporeCellResults.push(injectLiveSporeCellResult);
+  }
+
+  // Generate TransferSpore actions
+  const actions: (Partial<Pick<{ scriptInfoHash: string; scriptHash: string; data: string }, never>> &
+    Pick<{ scriptInfoHash: string; scriptHash: string; data: string }, 'data' | 'scriptInfoHash' | 'scriptHash'>)[] =
+    [];
+  for (const injectLiveSporeCellResult of injectLiveSporeCellResults) {
+    const actionResult = generateTransferSporeAction({
+      txSkeleton,
+      inputIndex: injectLiveSporeCellResult.inputIndex,
+      outputIndex: injectLiveSporeCellResult.outputIndex,
+    });
+    actions.push(...actionResult.actions);
+  }
+
+  if (!useCapacityMarginAsFee) {
+    // Inject needed capacity from fromInfos and pay fee
+    const injectCapacityAndPayFeeResult = await injectCapacityAndPayFee({
+      txSkeleton,
+      fromInfos: props.fromInfos!,
+      changeAddress: props.changeAddress,
+      feeRate: props.feeRate,
+      updateTxSkeletonAfterCollection(_txSkeleton) {
+        // Inject CobuildProof
+        const injectCobuildProofResult = injectCommonCobuildProof({
+          txSkeleton: _txSkeleton,
+          actions: actions,
+        });
+        _txSkeleton = injectCobuildProofResult.txSkeleton;
+
+        return _txSkeleton;
+      },
+      config,
+    });
+    txSkeleton = injectCapacityAndPayFeeResult.txSkeleton;
+  } else {
+    // Inject CobuildProof
+    const injectCobuildProofResult = injectCommonCobuildProof({
+      txSkeleton: txSkeleton,
+      actions: actions,
+    });
+    txSkeleton = injectCobuildProofResult.txSkeleton;
+
+    // choose an output to pay the fee
+    for (const item of injectLiveSporeCellResults) {
+      // Pay fee by the spore cell's capacity margin
+      try {
+        const tkSkeletonNew = await payFeeByOutput({
+          outputIndex: item.outputIndex,
+          txSkeleton,
+          config,
+        });
+        txSkeleton = tkSkeletonNew;
+        break;
+      } catch {
+        // if an error throwed, try next one, until it loops out
+        continue;
+      }
+    }
+  }
+
+  return txSkeleton;
 }

--- a/packages/core/src/api/composed/spore/transferSpore.ts
+++ b/packages/core/src/api/composed/spore/transferSpore.ts
@@ -133,7 +133,11 @@ export async function transferMultipleSpore(props: {
   since?: PackedSince;
   feeRate?: BIish | undefined;
   config?: SporeConfig;
-}): Promise<helpers.TransactionSkeletonType> {
+}): Promise<{
+  txSkeleton: helpers.TransactionSkeletonType;
+  inputIndecies: number[];
+  outputIndecies: number[];
+}> {
   // Env
   const config = props.config ?? getSporeConfig();
   const indexer = new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl);
@@ -237,5 +241,9 @@ export async function transferMultipleSpore(props: {
     }
   }
 
-  return txSkeleton;
+  return {
+    txSkeleton,
+    inputIndecies: injectLiveSporeCellResults.map((cell) => cell.inputIndex),
+    outputIndecies: injectLiveSporeCellResults.map((cell) => cell.outputIndex),
+  };
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -10,6 +10,7 @@ export * from './composed/cluster/transferCluster';
 export * from './composed/spore/createSpore';
 export * from './composed/spore/transferSpore';
 export * from './composed/spore/meltSpore';
+export * from './composed/spore/meltThenCreateSpore';
 
 // ClusterProxy
 export * from './composed/clusterProxy/createClusterProxy';


### PR DESCRIPTION
## What does this PR do

This PR adds a `Multiple-`variants for function `transferSpore`,  `meltThenCreateSpore`, brings the ability to operate multiple Spore assets in a single compacted transaction.

Also adds the necessary unit test for these two function.

## About Fee payments behavior

I've also checked and fixed the fee payment part of the original `meltThenCreateSpore`.

The *Zero-Fee* feature will only happens if:

1. Sum of `[inputs.capacity]` is greater than `[outputs.capacity]`
2. `[inputs.capacity] - [outputs.capacity]` is greater than minimal current on-chain fee-rate