### PR TITLE
bug: errors from getSporeById are mixed

### DIFF
--- a/.changeset/khaki-elephants-behave.md
+++ b/.changeset/khaki-elephants-behave.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+fix vulnerability in getSporeById interface

--- a/packages/core/src/api/joints/spore/getSpore.ts
+++ b/packages/core/src/api/joints/spore/getSpore.ts
@@ -63,19 +63,13 @@ export async function getSporeById(id: HexString, config?: SporeConfig): Promise
   // Get SporeType script
   const sporeScript = getSporeScriptCategory(config, 'Spore');
   const scripts = (sporeScript.versions ?? []).map((r) => r.script);
+  const indexer = new Indexer(config.ckbIndexerUrl, config.ckbNodeUrl);
 
   // Search target spore from the latest version to the oldest
   for (const script of scripts) {
-    try {
-      return await getSporeByType(
-        {
-          ...script,
-          args: id,
-        },
-        config,
-      );
-    } catch {
-      // Not found in the script, don't have to do anything
+    const cell = await getCellByType({ type: { ...script, args: id }, indexer });
+    if (cell !== void 0) {
+      return cell;
     }
   }
 


### PR DESCRIPTION
# Description
there's vulnerability in `getSporeById` interface, which is that errors thrown from it are mixed, it makes confuse