### PR TITLE
feat: add several signers

### DIFF
--- a/.changeset/funny-kiwis-ring.md
+++ b/.changeset/funny-kiwis-ring.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+Add JoyId, UtxoGlobal and PrivateKey wallet support

--- a/.changeset/funny-kiwis-ring.md
+++ b/.changeset/funny-kiwis-ring.md
@@ -2,4 +2,4 @@
 '@spore-sdk/core': patch
 ---
 
-Add JoyId, UtxoGlobal and PrivateKey wallet support
+Add JoyId, UtxoGlobal, Metamask and PrivateKey wallet support

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@ckb-ccc/core": "0.0.11-alpha.3",
+    "@ckb-ccc/eip6963": "0.0.11-alpha.3",
     "@ckb-ccc/joy-id": "0.0.11-alpha.3",
     "@ckb-ccc/utxo-global": "0.0.11-alpha.3"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,8 +21,8 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "vitest": "^1.4.0",
-    "@exact-realty/multipart-parser": "^1.0.13"
+    "@exact-realty/multipart-parser": "^1.0.13",
+    "vitest": "^1.4.0"
   },
   "publishConfig": {
     "access": "public"
@@ -33,5 +33,10 @@
   },
   "bugs": {
     "url": "https://github.com/sporeprotocol/spore-sdk/issues"
+  },
+  "dependencies": {
+    "@ckb-ccc/core": "0.0.11-alpha.3",
+    "@ckb-ccc/joy-id": "0.0.11-alpha.3",
+    "@ckb-ccc/utxo-global": "0.0.11-alpha.3"
   }
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -62,3 +62,12 @@ export * from './joints/mutant/injectNewMutantIds';
 export * from './joints/mutant/injectLiveMutantCell';
 export * from './joints/mutant/injectLiveMutantReferences';
 export * from './joints/mutant/getMutant';
+
+/**
+ * Signers
+ */
+
+export * from './signers/joyId';
+export * from './signers/privkey';
+export * from './signers/utxoGlobal';
+// TODO: Metamask Support

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -67,7 +67,8 @@ export * from './joints/mutant/getMutant';
  * Signers
  */
 
+export * from './signers/abstract';
 export * from './signers/joyId';
 export * from './signers/privkey';
 export * from './signers/utxoGlobal';
-// TODO: Metamask Support
+export * from './signers/eip6963';

--- a/packages/core/src/api/signers/abstract.ts
+++ b/packages/core/src/api/signers/abstract.ts
@@ -1,0 +1,30 @@
+import { helpers } from '@ckb-lumos/lumos';
+import { ccc } from '@ckb-ccc/core';
+
+/**
+ * Sign a Lumos transaction with the specified signer.
+ *
+ * @param skeleton The Lumos transaction skeleton.
+ * @param signer An abstract signer from ccc to sign the transaction.
+ * @param send Whether to send the transaction after signing. Default is false.
+ * @returns The signed transaction and the transaction hash if `send` is set to True.
+ */
+export async function signTransaction(props: {
+  skeleton: helpers.TransactionSkeletonType;
+  signer: ccc.Signer;
+  send?: boolean;
+}): Promise<{
+  cccTx: ccc.Transaction;
+  txHash?: ccc.Hex;
+}> {
+  const send = props.send ?? false;
+  const signer = props.signer;
+  const tx = ccc.Transaction.fromLumosSkeleton(props.skeleton);
+  const signedTx = await signer.signTransaction(tx);
+  if (send) {
+    const txHash = await signer.sendTransaction(signedTx);
+    return { cccTx: signedTx, txHash };
+  } else {
+    return { cccTx: signedTx };
+  }
+}

--- a/packages/core/src/api/signers/eip6963.ts
+++ b/packages/core/src/api/signers/eip6963.ts
@@ -1,0 +1,63 @@
+import { ccc } from '@ckb-ccc/core';
+import { Eip6963 } from '@ckb-ccc/eip6963';
+import { ProviderDetail } from '@ckb-ccc/eip6963/src/eip6963.advanced';
+import { helpers } from '@ckb-lumos/lumos';
+import { signTransaction } from './abstract';
+
+let mainnetEip6963Signer: Eip6963.Signer | undefined = undefined;
+let testnetEip6963Signer: Eip6963.Signer | undefined = undefined;
+
+/**
+ * Get the raw Eip6963 signer according to the network type.
+ *
+ * @param network The network type, either "mainnet" or "testnet".
+ * @returns The Eip6963 signer.
+ */
+export function getEip6963Signer(network: 'mainnet' | 'testnet'): Eip6963.Signer {
+  const windowRef = window as { ethereum?: ProviderDetail };
+
+  if (!windowRef.ethereum) {
+    throw new Error('Eip6963 compatible wallet is not loaded');
+  }
+
+  if (network === 'mainnet') {
+    if (mainnetEip6963Signer) {
+      return mainnetEip6963Signer;
+    }
+    const client = new ccc.ClientPublicMainnet();
+    mainnetEip6963Signer = new Eip6963.Signer(client, windowRef.ethereum);
+    return mainnetEip6963Signer;
+  } else {
+    if (testnetEip6963Signer) {
+      return testnetEip6963Signer;
+    }
+    const client = new ccc.ClientPublicTestnet();
+    testnetEip6963Signer = new Eip6963.Signer(client, windowRef.ethereum);
+    return testnetEip6963Signer;
+  }
+}
+
+/**
+ * Sign a Lumos transaction with Eip6963 compatible wallet.
+ *
+ * @param skeleton The Lumos transaction skeleton.
+ * @param network The network type, either "mainnet" or "testnet".
+ * @param send Whether to send the transaction after signing. Default is false.
+ * @returns The signed transaction and the transaction hash if `send` is set to True.
+ */
+export async function signTransactionWithEip6963CompatibleWallet(props: {
+  skeleton: helpers.TransactionSkeletonType;
+  network: 'mainnet' | 'testnet';
+  privkey: ccc.Hex;
+  send?: boolean;
+}): Promise<{
+  cccTx: ccc.Transaction;
+  txHash?: ccc.Hex;
+}> {
+  const send = props.send ?? false;
+  const signer = getEip6963Signer(props.network);
+  if (!signer.isConnected()) {
+    await signer.connect();
+  }
+  return await signTransaction({ skeleton: props.skeleton, signer, send });
+}

--- a/packages/core/src/api/signers/joyId.ts
+++ b/packages/core/src/api/signers/joyId.ts
@@ -1,0 +1,71 @@
+import { ccc } from '@ckb-ccc/core';
+import { JoyId } from '@ckb-ccc/joy-id';
+import { helpers } from '@ckb-lumos/lumos';
+
+let mainnetJoyIdSigner: JoyId.CkbSigner | undefined = undefined;
+let testnetJoyIdSigner: JoyId.CkbSigner | undefined = undefined;
+
+export interface SignerInfo {
+  network: 'mainnet' | 'testnet';
+  name: string;
+  url: string;
+}
+
+/**
+ * Get the raw JoyId signer according to the network type.
+ *
+ * @param signerInfo The Indicator of network type and JoyId considered information.
+ * @returns JoyId signer for CKB specific.
+ */
+export function getJoyIdSigner(signerInfo: SignerInfo): JoyId.CkbSigner {
+  if (signerInfo.network === 'mainnet') {
+    if (mainnetJoyIdSigner) {
+      return mainnetJoyIdSigner;
+    }
+    const client = new ccc.ClientPublicMainnet();
+    mainnetJoyIdSigner = new JoyId.CkbSigner(client, signerInfo.name, signerInfo.url);
+    return mainnetJoyIdSigner;
+  } else {
+    if (testnetJoyIdSigner) {
+      return testnetJoyIdSigner;
+    }
+    const client = new ccc.ClientPublicTestnet();
+    testnetJoyIdSigner = new JoyId.CkbSigner(client, signerInfo.name, signerInfo.url);
+    return testnetJoyIdSigner;
+  }
+}
+
+/**
+ * Sign a Lumos transaction with JoyId.
+ *
+ * @param skeleton The Lumos transaction skeleton.
+ * @param signerInfo The Indicator of network type and JoyId considered information.
+ * @param send Whether to send the transaction after signing. Default is false.
+ * @returns The signed transaction and the transaction hash if `send` is True.
+ */
+export async function signTransactionWithJoyId(props: {
+  skeleton: helpers.TransactionSkeletonType;
+  signerInfo: SignerInfo;
+  send?: boolean;
+}): Promise<{
+  cccTx: ccc.Transaction;
+  txHash?: ccc.Hex;
+}> {
+  const send = props.send ?? false;
+  const signer = getJoyIdSigner(props.signerInfo);
+  if (!signer.isConnected()) {
+    await signer.connect();
+  }
+  const tx = ccc.Transaction.fromLumosSkeleton(props.skeleton);
+  const signedTx = await signer.signTransaction(tx);
+
+  let txHash: ccc.Hex | undefined = undefined;
+  if (send) {
+    txHash = await signer.client.sendTransaction(signedTx);
+  }
+
+  return {
+    cccTx: signedTx,
+    txHash,
+  };
+}

--- a/packages/core/src/api/signers/privkey.ts
+++ b/packages/core/src/api/signers/privkey.ts
@@ -1,0 +1,43 @@
+import { helpers } from '@ckb-lumos/lumos';
+import { ccc } from '@ckb-ccc/core';
+
+/**
+ * Sign a Lumos transaction with a private key in direct, mostly used in backend server.
+ *
+ * @param skeleton The Lumos transaction skeleton.
+ * @param network The network type, either "mainnet" or "testnet".
+ * @param privkey The private key in hex format.
+ * @param send Whether to send the transaction after signing. Default is false.
+ * @returns The signed transaction and the transaction hash if `send` is True.
+ */
+export async function signTransactionWithPrivateKey(props: {
+  skeleton: helpers.TransactionSkeletonType;
+  network: 'mainnet' | 'testnet';
+  privkey: ccc.Hex;
+  send?: boolean;
+}): Promise<{
+  cccTx: ccc.Transaction;
+  txHash?: ccc.Hex;
+}> {
+  let client: ccc.Client | undefined = undefined;
+  if (props.network === 'mainnet') {
+    client = new ccc.ClientPublicMainnet();
+  } else {
+    client = new ccc.ClientPublicTestnet();
+  }
+
+  const send = props.send ?? false;
+  const tx = ccc.Transaction.fromLumosSkeleton(props.skeleton);
+  const privkeySigner = new ccc.SignerCkbPrivateKey(client, props.privkey);
+  const signedTx = await privkeySigner.signTransaction(tx);
+
+  let txHash: ccc.Hex | undefined = undefined;
+  if (send) {
+    txHash = await client.sendTransaction(signedTx);
+  }
+
+  return {
+    cccTx: signedTx,
+    txHash,
+  };
+}

--- a/packages/core/src/api/signers/utxoGlobal.ts
+++ b/packages/core/src/api/signers/utxoGlobal.ts
@@ -1,0 +1,77 @@
+import { helpers } from '@ckb-lumos/lumos';
+import { ccc } from '@ckb-ccc/core';
+import { UtxoGlobal } from '@ckb-ccc/utxo-global';
+import { Provider } from '@ckb-ccc/utxo-global/src/advancedBarrel';
+
+let mainnetUtxoGlobalSigner: UtxoGlobal.SignerCkb | undefined = undefined;
+let testnetUtxoGlobalSigner: UtxoGlobal.SignerCkb | undefined = undefined;
+
+/**
+ * Get the raw UtxoGlobal signer according to the network type.
+ *
+ * @param network The network type, either "mainnet" or "testnet".
+ * @returns The UtxoGlobal signer for CKB specific.
+ */
+export function getUtxoGlobalSigner(network: 'mainnet' | 'testnet'): UtxoGlobal.SignerCkb {
+  const windowRef = window as {
+    utxoGlobal?: {
+      bitcoinSigner: Provider;
+      ckbSigner: Provider;
+    };
+  };
+
+  if (typeof windowRef.utxoGlobal === 'undefined') {
+    throw new Error('UtxoGlobal is not loaded');
+  }
+
+  if (network === 'mainnet') {
+    if (mainnetUtxoGlobalSigner) {
+      return mainnetUtxoGlobalSigner;
+    }
+    const client = new ccc.ClientPublicMainnet();
+    mainnetUtxoGlobalSigner = new UtxoGlobal.SignerCkb(client, windowRef.utxoGlobal.ckbSigner);
+    return mainnetUtxoGlobalSigner;
+  } else {
+    if (testnetUtxoGlobalSigner) {
+      return testnetUtxoGlobalSigner;
+    }
+    const client = new ccc.ClientPublicTestnet();
+    testnetUtxoGlobalSigner = new UtxoGlobal.SignerCkb(client, windowRef.utxoGlobal.ckbSigner);
+    return testnetUtxoGlobalSigner;
+  }
+}
+
+/**
+ * Sign a Lumos transaction with UtxoGlobal, the web browser extension.
+ *
+ * @param skeleton The Lumos transaction skeleton.
+ * @param network The network type, either "mainnet" or "testnet".
+ * @param send Whether to send the transaction after signing. Default is false.
+ * @returns The signed transaction and the transaction hash if `send` is set to True.
+ */
+export async function signTransactionWithUtxoGlobal(props: {
+  skeleton: helpers.TransactionSkeletonType;
+  network: 'mainnet' | 'testnet';
+  send?: boolean;
+}): Promise<{
+  cccTx: ccc.Transaction;
+  txHash: ccc.Hex;
+}> {
+  const send = props.send ?? false;
+  const signer = getUtxoGlobalSigner(props.network);
+  if (!signer.isConnected()) {
+    await signer.connect();
+  }
+  const tx = ccc.Transaction.fromLumosSkeleton(props.skeleton);
+  const signedTx = await signer.signTransaction(tx);
+
+  let txHash: ccc.Hex | undefined = undefined;
+  if (send) {
+    txHash = await signer.client.sendTransaction(signedTx);
+  }
+
+  return {
+    cccTx: signedTx,
+    txHash: txHash!,
+  };
+}

--- a/packages/core/src/api/signers/utxoGlobal.ts
+++ b/packages/core/src/api/signers/utxoGlobal.ts
@@ -2,6 +2,7 @@ import { helpers } from '@ckb-lumos/lumos';
 import { ccc } from '@ckb-ccc/core';
 import { UtxoGlobal } from '@ckb-ccc/utxo-global';
 import { Provider } from '@ckb-ccc/utxo-global/src/advancedBarrel';
+import { signTransaction } from './abstract';
 
 let mainnetUtxoGlobalSigner: UtxoGlobal.SignerCkb | undefined = undefined;
 let testnetUtxoGlobalSigner: UtxoGlobal.SignerCkb | undefined = undefined;
@@ -55,23 +56,12 @@ export async function signTransactionWithUtxoGlobal(props: {
   send?: boolean;
 }): Promise<{
   cccTx: ccc.Transaction;
-  txHash: ccc.Hex;
+  txHash?: ccc.Hex;
 }> {
   const send = props.send ?? false;
   const signer = getUtxoGlobalSigner(props.network);
   if (!signer.isConnected()) {
     await signer.connect();
   }
-  const tx = ccc.Transaction.fromLumosSkeleton(props.skeleton);
-  const signedTx = await signer.signTransaction(tx);
-
-  let txHash: ccc.Hex | undefined = undefined;
-  if (send) {
-    txHash = await signer.client.sendTransaction(signedTx);
-  }
-
-  return {
-    cccTx: signedTx,
-    txHash: txHash!,
-  };
+  return await signTransaction({ skeleton: props.skeleton, signer, send });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@ckb-ccc/core':
         specifier: 0.0.11-alpha.3
         version: 0.0.11-alpha.3(typescript@5.3.2)
+      '@ckb-ccc/eip6963':
+        specifier: 0.0.11-alpha.3
+        version: 0.0.11-alpha.3(typescript@5.3.2)
       '@ckb-ccc/joy-id':
         specifier: 0.0.11-alpha.3
         version: 0.0.11-alpha.3(typescript@5.3.2)
@@ -349,6 +352,18 @@ packages:
       buffer: 6.0.3
       cross-fetch: 4.0.0
       ethers: 6.13.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@ckb-ccc/eip6963@0.0.11-alpha.3(typescript@5.3.2):
+    resolution: {integrity: sha512-sP6l938c6rgooYKX80oBBR9xTJaJMRTrkyziXKQijNWTeGM7iq9mjDjDkzWj4oYK5yvitUwEMByzG6IeeDWmMg==}
+    dependencies:
+      '@ckb-ccc/core': 0.0.11-alpha.3(typescript@5.3.2)
     transitivePeerDependencies:
       - bufferutil
       - encoding

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
   examples/omnilock:
     dependencies:
       '@ckb-lumos/lumos':
-        specifier: examples/acp/package.json
-        version: link:examples/acp/package.json
+        specifier: 0.24.0-next.1
+        version: 0.24.0-next.1
       '@spore-examples/shared':
         specifier: workspace:^
         version: link:../shared
@@ -93,6 +93,15 @@ importers:
 
   packages/core:
     dependencies:
+      '@ckb-ccc/core':
+        specifier: 0.0.11-alpha.3
+        version: 0.0.11-alpha.3(typescript@5.3.2)
+      '@ckb-ccc/joy-id':
+        specifier: 0.0.11-alpha.3
+        version: 0.0.11-alpha.3(typescript@5.3.2)
+      '@ckb-ccc/utxo-global':
+        specifier: 0.0.11-alpha.3
+        version: 0.0.11-alpha.3(typescript@5.3.2)
       '@ckb-lumos/lumos':
         specifier: 0.24.0-next.1
         version: 0.24.0-next.1
@@ -108,6 +117,10 @@ importers:
         version: 1.4.0(@types/node@20.4.1)
 
 packages:
+
+  /@adraffy/ens-normalize@1.10.1:
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+    dev: false
 
   /@babel/code-frame@7.22.5:
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
@@ -321,6 +334,69 @@ packages:
       prettier: 2.8.7
     dev: true
 
+  /@ckb-ccc/core@0.0.11-alpha.3(typescript@5.3.2):
+    resolution: {integrity: sha512-2+K6D7rdEFhDSqaiw4Crbe75p0urPOQ8hePJl/FTqGhengOOcBqp4G14+NXPHhS/S58r+V0kmg3zrRIRXBKPGQ==}
+    dependencies:
+      '@ckb-lumos/helpers': 0.22.2
+      '@joyid/ckb': 1.0.1(typescript@5.3.2)
+      '@noble/ciphers': 0.5.3
+      '@noble/curves': 1.5.0
+      '@noble/hashes': 1.4.0
+      abort-controller: 3.0.0
+      bech32: 2.0.0
+      bitcoinjs-message: 2.2.0
+      blake2b: 2.1.4
+      buffer: 6.0.3
+      cross-fetch: 4.0.0
+      ethers: 6.13.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@ckb-ccc/joy-id@0.0.11-alpha.3(typescript@5.3.2):
+    resolution: {integrity: sha512-FvHOBcTc5SmCvYZSf1fbUJN81goKDX9vkK9H33x2jneCpXZds+wiT0uqnkZM7s0kTsQkUBAqYHlfJPhYFL8O9w==}
+    dependencies:
+      '@ckb-ccc/core': 0.0.11-alpha.3(typescript@5.3.2)
+      '@joyid/ckb': 1.0.1(typescript@5.3.2)
+      '@joyid/common': 0.2.0(typescript@5.3.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@ckb-ccc/utxo-global@0.0.11-alpha.3(typescript@5.3.2):
+    resolution: {integrity: sha512-IWCPyOEtiasvH9za5tVXqS44j6QJgdnJ1rGA9cz/WuCGTEMUFCzOpmWF8O4WlbhMZJ7UCJDzHNZ69m3K8wsxag==}
+    dependencies:
+      '@ckb-ccc/core': 0.0.11-alpha.3(typescript@5.3.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@ckb-lumos/base@0.22.2:
+    resolution: {integrity: sha512-nosUCSa5rTV2IzxbEpqzrvUeQNXB66mgA0h40+QEdnE/gV/s4ke83AScrTAxWkErJy1G/sToIHCc2kWwO95DfQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/bi': 0.22.2
+      '@ckb-lumos/codec': 0.22.2
+      '@ckb-lumos/toolkit': 0.22.2
+      '@types/blake2b': 2.1.0
+      '@types/lodash.isequal': 4.5.6
+      blake2b: 2.1.4
+      js-xxhash: 1.0.4
+      lodash.isequal: 4.5.0
+    dev: false
+
   /@ckb-lumos/base@0.24.0-next.1:
     resolution: {integrity: sha512-p9veifS3aT0DqdIYWlG6jCUgA68m9baTDzyELIGU1RlLga0yXEElSkY9F534u6eqgriNWBb1b9imMV75sEPauw==}
     engines: {node: '>=12.0.0'}
@@ -332,6 +408,13 @@ packages:
       '@types/lodash.isequal': 4.5.6
       blake2b: 2.1.4
       js-xxhash: 1.0.4
+    dev: false
+
+  /@ckb-lumos/bi@0.22.2:
+    resolution: {integrity: sha512-F+dLC/tE+xdtNuGgJxlDqbgX/f8azg1tvIFTR5mu7Vhz08nkFgnA+Z+yC0t/I3fDwwH4p/SlGP/yducrsfVTqw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      jsbi: 4.3.0
     dev: false
 
   /@ckb-lumos/bi@0.24.0-next.1:
@@ -356,6 +439,13 @@ packages:
       - encoding
     dev: false
 
+  /@ckb-lumos/codec@0.22.2:
+    resolution: {integrity: sha512-P5SyhT2qkJwCwcHF3yMLInE0z3wWHDkqJNbSM2Q9oyu0+9kjMQfexNia3T+atBl2M7ELFzN5WvttojYr6DrCwQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/bi': 0.22.2
+    dev: false
+
   /@ckb-lumos/codec@0.24.0-next.1:
     resolution: {integrity: sha512-Nc0OtH3WZpa7Ryp/o7QodCuf49/806cz2J4S3KEhL7WZnPwHCwKAhpUNeRTubNzQRlRzUqok3/NoJAlKclOuhw==}
     engines: {node: '>=12.0.0'}
@@ -378,6 +468,20 @@ packages:
       bech32: 2.0.0
       bs58: 5.0.0
       immutable: 4.3.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@ckb-lumos/config-manager@0.22.2:
+    resolution: {integrity: sha512-LJ4p80VrCHh178Ks4wW1rEyHC/JWtZxrFiwHinA9aG6aOm2Z9hbZO0/ZKoS5pLfW0gxP2+ZHA3oMVt0UJhlTKA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/base': 0.22.2
+      '@ckb-lumos/bi': 0.22.2
+      '@ckb-lumos/codec': 0.22.2
+      '@ckb-lumos/rpc': 0.22.2
+      '@types/deep-freeze-strict': 1.1.0
+      deep-freeze-strict: 1.1.1
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -415,6 +519,21 @@ packages:
       bn.js: 4.12.0
       elliptic: 6.5.4
       uuid: 8.3.2
+    dev: false
+
+  /@ckb-lumos/helpers@0.22.2:
+    resolution: {integrity: sha512-6ztXwxsaCuoHjkbclAnfAv9BYl02t+/XxNtl3Et4Sl09xIp9HJ9/vyJouC9JjdQdnfkv1zVGN9tLiKwc6QudaQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/base': 0.22.2
+      '@ckb-lumos/bi': 0.22.2
+      '@ckb-lumos/codec': 0.22.2
+      '@ckb-lumos/config-manager': 0.22.2
+      '@ckb-lumos/toolkit': 0.22.2
+      bech32: 2.0.0
+      immutable: 4.3.0
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@ckb-lumos/helpers@0.24.0-next.1:
@@ -466,6 +585,18 @@ packages:
       - encoding
     dev: false
 
+  /@ckb-lumos/rpc@0.22.2:
+    resolution: {integrity: sha512-c2SX0ooDJO3dV2JOTTQtKZs0k+dHst+NHfbYJ6mYWApcZWx2nG4bQR3CQFMIKnd5CKYP/r2JuaonDkcRH9vmzw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/base': 0.22.2
+      '@ckb-lumos/bi': 0.22.2
+      abort-controller: 3.0.0
+      cross-fetch: 3.1.8
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /@ckb-lumos/rpc@0.24.0-next.1:
     resolution: {integrity: sha512-RBIqxxzmkdcSlgwyEv9ezW+x+uovVT7P5+6Ox8eEtoN6L/+hOgLH2MYzishFJXSn93H86GLz/9BPQ/0qx2wUWA==}
     engines: {node: '>=12.0.0'}
@@ -476,6 +607,13 @@ packages:
       cross-fetch: 3.1.8
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@ckb-lumos/toolkit@0.22.2:
+    resolution: {integrity: sha512-HmKz2dGQeaW2XDqkvjJfLv50VQWGKbthg2RDfIxGsZyjveluRROTyuHP1akypy4pqF8TApGLsXci2MaHCRau+w==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/bi': 0.22.2
     dev: false
 
   /@ckb-lumos/toolkit@0.24.0-next.1:
@@ -736,6 +874,29 @@ packages:
       '@sinclair/typebox': 0.27.8
     dev: true
 
+  /@joyid/ckb@1.0.1(typescript@5.3.2):
+    resolution: {integrity: sha512-pKAJouigChqcwKgtLw4RNOwi+nBh3NVjpU+qZd+uu3wmoTpivnSRLbJH8/SlkgQcWn2aJ+mDJchR8GpQYh5H6Q==}
+    dependencies:
+      '@joyid/common': 0.2.0(typescript@5.3.2)
+      '@nervosnetwork/ckb-sdk-utils': 0.109.3
+      cross-fetch: 4.0.0
+      uncrypto: 0.1.3
+    transitivePeerDependencies:
+      - encoding
+      - typescript
+      - zod
+    dev: false
+
+  /@joyid/common@0.2.0(typescript@5.3.2):
+    resolution: {integrity: sha512-WBZtgdEccWxjiGHIoDgRFIbnC42ZvmfvFRCTxmx9D4BLvtiFdhAa+g70lUmiHwO28GjgHIHgzHRGNRdLuk81xw==}
+    dependencies:
+      abitype: 0.8.7(typescript@5.3.2)
+      type-fest: 4.6.0
+    transitivePeerDependencies:
+      - typescript
+      - zod
+    dev: false
+
   /@jridgewell/resolve-uri@3.1.1:
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
@@ -769,8 +930,39 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
+  /@nervosnetwork/ckb-sdk-utils@0.109.3:
+    resolution: {integrity: sha512-sV3WXlZmd765qtFsXpwl0Bl3hOgGev15Og810acO6iC0cVHEVvv/Uiabd8a2xkqyfziRDI0tfWC0DewOJB28rg==}
+    dependencies:
+      '@nervosnetwork/ckb-types': 0.109.3
+      bech32: 2.0.0
+      elliptic: 6.5.4
+      jsbi: 3.1.3
+      tslib: 2.3.1
+    dev: false
+
+  /@nervosnetwork/ckb-types@0.109.3:
+    resolution: {integrity: sha512-i9EVTXCT0bTLpAQXAoF5zHGLWYCXNE5AP4Zl0Niwl3ZplaVAZHNU6ygsh2O3EGmCFv5qlkoY2DuLmsjysEaNLA==}
+    dev: false
+
   /@noble/ciphers@0.5.3:
     resolution: {integrity: sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==}
+    dev: false
+
+  /@noble/curves@1.2.0:
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+    dev: false
+
+  /@noble/curves@1.5.0:
+    resolution: {integrity: sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==}
+    dependencies:
+      '@noble/hashes': 1.4.0
+    dev: false
+
+  /@noble/hashes@1.3.2:
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
     dev: false
 
   /@noble/hashes@1.4.0:
@@ -962,6 +1154,10 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
+  /@types/node@18.15.13:
+    resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
+    dev: false
+
   /@types/node@20.4.1:
     resolution: {integrity: sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==}
 
@@ -1012,6 +1208,18 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
+  /abitype@0.8.7(typescript@5.3.2):
+    resolution: {integrity: sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.3.2
+    dev: false
+
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -1032,6 +1240,10 @@ packages:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  /aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+    dev: false
 
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1128,8 +1340,22 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: false
 
+  /base-x@3.0.10:
+    resolution: {integrity: sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
   /base-x@4.0.0:
     resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
+    dev: false
+
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /bech32@1.1.4:
+    resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
     dev: false
 
   /bech32@2.0.0:
@@ -1142,6 +1368,30 @@ packages:
     dependencies:
       is-windows: 1.0.2
     dev: true
+
+  /bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    dependencies:
+      file-uri-to-path: 1.0.0
+    dev: false
+
+  /bip66@1.1.5:
+    resolution: {integrity: sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /bitcoinjs-message@2.2.0:
+    resolution: {integrity: sha512-103Wy3xg8Y9o+pdhGP4M3/mtQQuUWs6sPuOp1mYphSUoSMHjHTlkj32K4zxU8qMH0Ckv23emfkGlFWtoWZ7YFA==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      bech32: 1.1.4
+      bs58check: 2.1.2
+      buffer-equals: 1.0.4
+      create-hash: 1.2.0
+      secp256k1: 3.8.0
+      varuint-bitcoin: 1.1.2
+    dev: false
 
   /blake2b-wasm@2.4.0:
     resolution: {integrity: sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==}
@@ -1184,10 +1434,51 @@ packages:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
     dev: false
 
+  /browserify-aes@1.2.0:
+    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
+    dependencies:
+      buffer-xor: 1.0.3
+      cipher-base: 1.0.4
+      create-hash: 1.2.0
+      evp_bytestokey: 1.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
+
+  /bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+    dependencies:
+      base-x: 3.0.10
+    dev: false
+
   /bs58@5.0.0:
     resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
     dependencies:
       base-x: 4.0.0
+    dev: false
+
+  /bs58check@2.1.2:
+    resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}
+    dependencies:
+      bs58: 4.0.1
+      create-hash: 1.2.0
+      safe-buffer: 5.2.1
+    dev: false
+
+  /buffer-equals@1.0.4:
+    resolution: {integrity: sha512-99MsCq0j5+RhubVEtKQgKaD6EM+UP3xJgIvQqwJ3SOLDUekzxMX1ylXBng+Wa2sh7mGT0W6RUly8ojjr1Tt6nA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /buffer-xor@1.0.3:
+    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
+    dev: false
+
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
     dev: false
 
   /cac@6.7.14:
@@ -1266,6 +1557,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /cipher-base@1.0.4:
+    resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
+
   /cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1331,11 +1629,40 @@ packages:
     engines: {node: '>=16'}
     dev: true
 
+  /create-hash@1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+    dependencies:
+      cipher-base: 1.0.4
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.2
+      sha.js: 2.4.11
+    dev: false
+
+  /create-hmac@1.1.7:
+    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
+    dependencies:
+      cipher-base: 1.0.4
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.1
+      sha.js: 2.4.11
+    dev: false
+
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
   /cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
+    dependencies:
+      node-fetch: 2.6.12
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /cross-fetch@4.0.0:
+    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
     dependencies:
       node-fetch: 2.6.12
     transitivePeerDependencies:
@@ -1450,6 +1777,15 @@ packages:
     dependencies:
       path-type: 4.0.0
     dev: true
+
+  /drbg.js@1.0.1:
+    resolution: {integrity: sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      browserify-aes: 1.2.0
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+    dev: false
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1602,6 +1938,22 @@ packages:
       '@types/estree': 1.0.5
     dev: true
 
+  /ethers@6.13.2:
+    resolution: {integrity: sha512-9VkriTTed+/27BGuY1s0hf441kqwHJ1wtN2edksEtiRvXx+soxRX3iSXTfFqq2+YwrOqbDoTHjIhQnjJRlzKmg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 18.15.13
+      aes-js: 4.0.0-beta.5
+      tslib: 2.4.0
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -1614,6 +1966,13 @@ packages:
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+    dev: false
+
+  /evp_bytestokey@1.0.3:
+    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
+    dependencies:
+      md5.js: 1.3.5
+      safe-buffer: 5.2.1
     dev: false
 
   /execa@8.0.1:
@@ -1660,6 +2019,10 @@ packages:
     dependencies:
       reusify: 1.0.4
     dev: true
+
+  /file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    dev: false
 
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -1881,6 +2244,15 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /hash-base@3.1.0:
+    resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
+    engines: {node: '>=4'}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      safe-buffer: 5.2.1
+    dev: false
+
   /hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
     dependencies:
@@ -1921,6 +2293,10 @@ packages:
     dependencies:
       safer-buffer: 2.1.2
     dev: true
+
+  /ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: false
 
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -2138,6 +2514,10 @@ packages:
       esprima: 4.0.1
     dev: true
 
+  /jsbi@3.1.3:
+    resolution: {integrity: sha512-nBJqA0C6Qns+ZxurbEoIR56wyjiUszpNy70FHvxO5ervMoCbZVE3z3kxr5nKGhlxr/9MhKTSUBs7cAwwuf3g9w==}
+    dev: false
+
   /jsbi@4.3.0:
     resolution: {integrity: sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==}
     dev: false
@@ -2238,6 +2618,10 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    dev: false
+
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
@@ -2301,6 +2685,14 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /md5.js@1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
+    dependencies:
+      hash-base: 3.1.0
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
 
   /meow@6.1.1:
     resolution: {integrity: sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==}
@@ -2397,6 +2789,10 @@ packages:
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
+
+  /nan@2.20.0:
+    resolution: {integrity: sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==}
+    dev: false
 
   /nanoassert@2.0.0:
     resolution: {integrity: sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==}
@@ -2700,6 +3096,15 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: false
+
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -2769,6 +3174,13 @@ packages:
       glob: 10.3.3
     dev: false
 
+  /ripemd160@2.0.2:
+    resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
+    dependencies:
+      hash-base: 3.1.0
+      inherits: 2.0.4
+    dev: false
+
   /rollup@4.9.2:
     resolution: {integrity: sha512-66RB8OtFKUTozmVEh3qyNfH+b+z2RXBVloqO2KCC/pjFaGaHtxP9fVfOQKPSGXg2mElmjmxjW/fZ7iKrEpMH5Q==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2796,6 +3208,10 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
+
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
@@ -2807,6 +3223,21 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
+
+  /secp256k1@3.8.0:
+    resolution: {integrity: sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==}
+    engines: {node: '>=4.0.0'}
+    requiresBuild: true
+    dependencies:
+      bindings: 1.5.0
+      bip66: 1.1.5
+      bn.js: 4.12.0
+      create-hash: 1.2.0
+      drbg.js: 1.0.1
+      elliptic: 6.5.4
+      nan: 2.20.0
+      safe-buffer: 5.2.1
+    dev: false
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -2824,6 +3255,14 @@ packages:
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: true
+
+  /sha.js@2.4.11:
+    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+    hasBin: true
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
 
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
@@ -2997,6 +3436,12 @@ packages:
       es-abstract: 1.21.2
     dev: true
 
+  /string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3155,6 +3600,14 @@ packages:
       yn: 3.1.1
     dev: false
 
+  /tslib@2.3.1:
+    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+    dev: false
+
+  /tslib@2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: false
+
   /tty-table@4.2.1:
     resolution: {integrity: sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==}
     engines: {node: '>=8.0.0'}
@@ -3259,6 +3712,11 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
+  /type-fest@4.6.0:
+    resolution: {integrity: sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==}
+    engines: {node: '>=16'}
+    dev: false
+
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
@@ -3285,10 +3743,18 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
+  /uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+    dev: false
+
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
     dev: true
+
+  /util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false
 
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -3304,6 +3770,12 @@ packages:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
     dev: true
+
+  /varuint-bitcoin@1.1.2:
+    resolution: {integrity: sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
 
   /vite-node@1.4.0(@types/node@20.4.1):
     resolution: {integrity: sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==}
@@ -3516,6 +3988,19 @@ packages:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
+
+  /ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}


### PR DESCRIPTION
# Description
to reduce work load of `spore-sdk` programmers, we add several built-in signers, e.g. JoyId, UtxoGlobal, Metamask and plain private key.

note: programmers can refer to this PR and learn how to sign for the Spore transaction