### PR TITLE
bug: fix injectNeededCapacity rare border capacity issue

### DIFF
--- a/packages/core/src/api/joints/spore/injectLiveSporeCell.ts
+++ b/packages/core/src/api/joints/spore/injectLiveSporeCell.ts
@@ -48,11 +48,13 @@ export async function injectLiveSporeCell(props: {
     input: sporeCell,
     addOutput: props.addOutput,
     updateOutput(cell) {
-      if (props.capacityMargin !== void 0) {
-        cell = setAbsoluteCapacityMargin(cell, props.capacityMargin);
-      }
+      // May contain code about changing scripts, which causes the change of cell's occupied capacity,
+      // so here should be processed at first
       if (props.updateOutput instanceof Function) {
         cell = props.updateOutput(cell);
+      }
+      if (props.capacityMargin !== void 0) {
+        cell = setAbsoluteCapacityMargin(cell, props.capacityMargin);
       }
       return cell;
     },

--- a/packages/core/src/helpers/capacity.ts
+++ b/packages/core/src/helpers/capacity.ts
@@ -6,7 +6,6 @@ import { Address, Script, Cell } from '@ckb-lumos/base/lib';
 import { common, FromInfo } from '@ckb-lumos/common-scripts/lib';
 import { fromInfoToAddress } from './address';
 import { isScriptValueEquals } from './script';
-import {} from '@ckb-lumos/lumos/helpers';
 
 /**
  * Calculate target cell's minimal occupied capacity by lock script.
@@ -352,9 +351,6 @@ export function returnExceededCapacity(props: {
     };
     const minimalCapacity = helpers.minimalCellCapacityCompatible(changeCell);
     if (snapshot.inputsRemainCapacity.lt(minimalCapacity)) {
-      console.warn(
-        "The change cell's capacity is less than the minimal capacity, it may cause a failure in the future",
-      );
       unreturnedCapacity = snapshot.inputsRemainCapacity;
     } else {
       createdChangeCell = true;

--- a/packages/core/src/helpers/fee.ts
+++ b/packages/core/src/helpers/fee.ts
@@ -3,9 +3,10 @@ import { Address, Transaction } from '@ckb-lumos/base';
 import { BI, Header, helpers, RPC } from '@ckb-lumos/lumos';
 import { BIish } from '@ckb-lumos/bi';
 import { getSporeConfig, SporeConfig } from '../config';
-import { injectNeededCapacity, returnExceededCapacity } from './capacity';
+import { injectNeededCapacity, minimalCellCapacityByLock, returnExceededCapacity } from './capacity';
 import { CapacitySnapshot, createCapacitySnapshotFromTransactionSkeleton } from './capacity';
 import { getTransactionSize, getTransactionSkeletonSize } from './transaction';
+import { fromInfoToAddress } from './address';
 
 /**
  * Get minimal acceptable fee rate from RPC.
@@ -154,7 +155,7 @@ export async function injectCapacityAndPayFee(props: {
   feeRate?: BIish;
   extraCapacity?: BIish;
   changeAddress?: Address;
-  enableDeductCapacity?: boolean;
+  addChangeCell?: boolean;
   updateTxSkeletonAfterCollection?: (
     txSkeleton: helpers.TransactionSkeletonType,
   ) => Promise<helpers.TransactionSkeletonType> | helpers.TransactionSkeletonType;
@@ -165,6 +166,22 @@ export async function injectCapacityAndPayFee(props: {
 }> {
   // Env
   const config = props.config ?? getSporeConfig();
+  const addChangeCell = props.addChangeCell ?? true;
+
+  // Add new change cell if marked
+  if (addChangeCell) {
+    const changeAddress = fromInfoToAddress(props.changeAddress ?? props.fromInfos[0], config.lumos);
+    const changeLock = helpers.addressToScript(changeAddress, { config: config.lumos });
+    props.txSkeleton = props.txSkeleton.update('outputs', (outputs) => {
+      return outputs.push({
+        cellOutput: {
+          capacity: minimalCellCapacityByLock(changeLock).toHexString(),
+          lock: changeLock,
+        },
+        data: '0x',
+      });
+    });
+  }
 
   // Collect capacity
   const injectNeededCapacityResult = await injectNeededCapacity({

--- a/packages/core/src/helpers/fee.ts
+++ b/packages/core/src/helpers/fee.ts
@@ -155,7 +155,6 @@ export async function injectCapacityAndPayFee(props: {
   feeRate?: BIish;
   extraCapacity?: BIish;
   changeAddress?: Address;
-  addChangeCell?: boolean;
   updateTxSkeletonAfterCollection?: (
     txSkeleton: helpers.TransactionSkeletonType,
   ) => Promise<helpers.TransactionSkeletonType> | helpers.TransactionSkeletonType;
@@ -166,22 +165,19 @@ export async function injectCapacityAndPayFee(props: {
 }> {
   // Env
   const config = props.config ?? getSporeConfig();
-  const addChangeCell = props.addChangeCell ?? true;
 
-  // Add new change cell if marked
-  if (addChangeCell) {
-    const changeAddress = fromInfoToAddress(props.changeAddress ?? props.fromInfos[0], config.lumos);
-    const changeLock = helpers.addressToScript(changeAddress, { config: config.lumos });
-    props.txSkeleton = props.txSkeleton.update('outputs', (outputs) => {
-      return outputs.push({
-        cellOutput: {
-          capacity: minimalCellCapacityByLock(changeLock).toHexString(),
-          lock: changeLock,
-        },
-        data: '0x',
-      });
+  // Add a new change cell for receiving change capacity as default
+  const changeAddress = fromInfoToAddress(props.changeAddress ?? props.fromInfos[0], config.lumos);
+  const changeLock = helpers.addressToScript(changeAddress, { config: config.lumos });
+  props.txSkeleton = props.txSkeleton.update('outputs', (outputs) => {
+    return outputs.push({
+      cellOutput: {
+        capacity: minimalCellCapacityByLock(changeLock).toHexString(),
+        lock: changeLock,
+      },
+      data: '0x',
     });
-  }
+  });
 
   // Collect capacity
   const injectNeededCapacityResult = await injectNeededCapacity({


### PR DESCRIPTION
# Description
while balancing transaction, if exceeded capacity cannot cover the capacity of minimal change cell, spore-sdk only requires to inject this minimal capacity yet, which is wrong without adding a minimal change cell.