### PR TITLE
fix: all of payFeeByOutput invokes missed passing feeRate

### DIFF
--- a/.changeset/beige-penguins-melt.md
+++ b/.changeset/beige-penguins-melt.md
@@ -1,0 +1,5 @@
+---
+'@spore-sdk/core': patch
+---
+
+passing feeRate to payFeeByOutput method

--- a/packages/core/src/api/composed/cluster/transferCluster.ts
+++ b/packages/core/src/api/composed/cluster/transferCluster.ts
@@ -108,6 +108,7 @@ export async function transferCluster(props: {
     // Pay fee by the cluster cell's capacity margin
     txSkeleton = await payFeeByOutput({
       outputIndex: injectLiveClusterCellResult.outputIndex,
+      feeRate: props.feeRate,
       txSkeleton,
       config,
     });

--- a/packages/core/src/api/composed/clusterAgent/transferClusterAgent.ts
+++ b/packages/core/src/api/composed/clusterAgent/transferClusterAgent.ts
@@ -108,6 +108,7 @@ export async function transferClusterAgent(props: {
     // Pay fee by the target cell's capacity margin
     txSkeleton = await payFeeByOutput({
       txSkeleton,
+      feeRate: props.feeRate,
       outputIndex: injectLiveClusterAgentCellResult.outputIndex,
       config,
     });

--- a/packages/core/src/api/composed/clusterProxy/transferClusterProxy.ts
+++ b/packages/core/src/api/composed/clusterProxy/transferClusterProxy.ts
@@ -110,6 +110,7 @@ export async function transferClusterProxy(props: {
     // Pay fee by the spore cell's capacity margin
     txSkeleton = await payFeeByOutput({
       outputIndex: injectLiveClusterProxyCellResult.outputIndex,
+      feeRate: props.feeRate,
       txSkeleton,
       config,
     });

--- a/packages/core/src/api/composed/mutant/transferMutant.ts
+++ b/packages/core/src/api/composed/mutant/transferMutant.ts
@@ -81,6 +81,7 @@ export async function transferMutant(props: {
     // Pay fee by the target cell's capacity margin
     txSkeleton = await payFeeByOutput({
       outputIndex: injectLiveMutantCellResult.outputIndex,
+      feeRate: props.feeRate,
       txSkeleton,
       config,
     });

--- a/packages/core/src/api/composed/spore/transferSpore.ts
+++ b/packages/core/src/api/composed/spore/transferSpore.ts
@@ -107,6 +107,7 @@ export async function transferSpore(props: {
     // Pay fee by the spore cell's capacity margin
     txSkeleton = await payFeeByOutput({
       outputIndex: injectLiveSporeCellResult.outputIndex,
+      feeRate: props.feeRate,
       txSkeleton,
       config,
     });
@@ -229,6 +230,7 @@ export async function transferMultipleSpore(props: {
       try {
         const tkSkeletonNew = await payFeeByOutput({
           outputIndex: item.outputIndex,
+          feeRate: props.feeRate,
           txSkeleton,
           config,
         });


### PR DESCRIPTION
# Description
I found all of payFeeByOutput method in the first invoke layer has missed feeRate parameter, which should be added for correction