### PR TITLE
Patch: packageManager & meltSpore

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "lint-staged": {
     "{packages,apps}/**/*.{js,jsx,ts,tsx,md,json}": "prettier --ignore-unknown --write"
   },
-  "packageManager": "^pnpm@8.0.0",
+  "packageManager": "pnpm@8.0.0",
   "engines": {
     "node": ">=18.0.0"
   }

--- a/packages/core/src/api/composed/spore/meltSpore.ts
+++ b/packages/core/src/api/composed/spore/meltSpore.ts
@@ -1,3 +1,4 @@
+import { BIish } from '@ckb-lumos/bi';
 import { Address, OutPoint } from '@ckb-lumos/base';
 import { Indexer, helpers, HexString, PackedSince } from '@ckb-lumos/lumos';
 import { returnExceededCapacityAndPayFee } from '../../../helpers';
@@ -12,6 +13,7 @@ export async function meltSpore(props: {
   defaultWitness?: HexString;
   since?: PackedSince;
   config?: SporeConfig;
+  feeRate?: BIish | undefined;
 }): Promise<{
   txSkeleton: helpers.TransactionSkeletonType;
   inputIndex: number;
@@ -57,6 +59,7 @@ export async function meltSpore(props: {
     changeAddress: props.changeAddress ?? sporeAddress,
     txSkeleton,
     config,
+    feeRate: props.feeRate,
   });
   txSkeleton = returnExceededCapacityAndPayFeeResult.txSkeleton;
 


### PR DESCRIPTION
- Add missing `feeRate` to meltSpore method
- Remove `^` from the `packageManager` as it causes an **ERROR** depending on Node version

![Screenshot 2024-10-05 214253](https://github.com/user-attachments/assets/ff6e544a-1bca-4ef3-a4c6-decfcc95476f)
